### PR TITLE
net-p2p/trezord-go: add openrc init script

### DIFF
--- a/net-p2p/trezord-go/files/trezord-openrc.sh
+++ b/net-p2p/trezord-go/files/trezord-openrc.sh
@@ -1,0 +1,9 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+command="/usr/bin/trezord"
+pidfile="/run/${RC_SVCNAME}.pid"
+command_args="-l /var/log/trezord/trezord.log"
+command_user="trezord"
+command_background=true

--- a/net-p2p/trezord-go/trezord-go-2.0.29.ebuild
+++ b/net-p2p/trezord-go/trezord-go-2.0.29.ebuild
@@ -24,6 +24,10 @@ DEPEND="
 
 src_install() {
 	newbin trezord-go trezord
+	newinitd "${FILESDIR}/trezord-openrc.sh" trezord
+	keepdir /var/log/trezord
+	fowners trezord:root /var/log/trezord
+
 	use systemd && systemd_dounit src/github.com/trezor/trezord-go/release/linux/trezord.service
 	use udev && udev_dorules src/github.com/trezor/trezord-go/release/linux/trezor.rules
 }


### PR DESCRIPTION
This adds an openrc init script for trezord-go.

Since I'm not the maintainer of the package the IRC channel suggested I make a PR and ping the maintainer @gcarq 