### PR TITLE
games-util/legendary: use single python target.

### DIFF
--- a/games-util/legendary/legendary-0.0.19-r1.ebuild
+++ b/games-util/legendary/legendary-0.0.19-r1.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_8 python3_9 )
+PYTHON_COMPAT=( python3_{8,9} )
+DISTUTILS_SINGLE_IMPL=1
 
 inherit distutils-r1
 
@@ -16,7 +17,9 @@ SLOT="0"
 KEYWORDS="~amd64"
 
 RDEPEND="
-	<dev-python/requests-3.0[${PYTHON_USEDEP}]
-	dev-python/wheel[${PYTHON_USEDEP}]
+	$(python_gen_cond_dep '
+		<dev-python/requests-3.0[${PYTHON_USEDEP}]
+		dev-python/wheel[${PYTHON_USEDEP}]
+	')
 "
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
@tastytea This is a proposed change to the  games-util/legendary ebuild.

This uses only a single implementation for python for an installation, which makes more sense in my opinion for a enduser program.

- https://dev.gentoo.org/~mgorny/python-guide/eclass.html#single-impl-vs-multi-impl
- https://dev.gentoo.org/~mgorny/python-guide/distutils.html#python-single-r1-variant