### PR TITLE
net-p2p/monero: fix build for musl

### DIFF
--- a/net-p2p/monero/monero-0.17.3.2.ebuild
+++ b/net-p2p/monero/monero-0.17.3.2.ebuild
@@ -52,6 +52,8 @@ src_configure() {
 		-DUSE_DEVICE_TREZOR=OFF
 	)
 
+	use elibc_musl && mycmakeargs+=( -DSTACK_TRACE=OFF )
+
 	cmake_src_configure
 }
 


### PR DESCRIPTION
This patch sets -DSTACK_TRACE=OFF when elibc_musl is
defined. Execinfo is not provided by musl libc and therefore the build
fails.

Other, and probably better solutions would be to not depend on
execinfo or to package a standalone
libexecinfo (https://github.com/mikroskeem/libexecinfo) and add it to
the DEPEND-array if using musl. But that's better to take upstream. I
think this is totally fine for most users for now.

Signed-off-by: Alfred Persson Forsberg <cat@catcream.org>