### PR TITLE
DNM: For review only sys-power/tlp: Remove unneeded use flags

### DIFF
--- a/sys-power/tlp/tlp-1.5.0.ebuild
+++ b/sys-power/tlp/tlp-1.5.0.ebuild
@@ -12,25 +12,22 @@ S="${WORKDIR}/TLP-${PV}"
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="bash-completion elogind systemd"
 RESTRICT="mirror"
+# It's uncertain if elogind/systemd is actually required, however, without the sleep
+# hooks working, which require one of them, it doesn't seem like this app is very useful.
 RDEPEND="virtual/udev
-		bash-completion? ( app-shells/bash app-shells/bash-completion )
-		elogind? ( sys-auth/elogind )
-		systemd? ( sys-apps/systemd )"
+		|| ( sys-auth/elogind sys-apps/systemd )"
 DEPEND="${RDEPEND}"
-REQUIRED_USE="?? ( elogind systemd )"
 
 src_install() {
 	emake \
 		DESTDIR="${D}" \
 		TLP_NO_INIT=1 \
-		TLP_NO_BASHCOMP=$(usex bash-completion 0 1) \
-		TLP_WITH_ELOGIND=$(usex elogind 1 0) \
-		TLP_WITH_SYSTEMD=$(usex systemd 1 0) \
+		TLP_WITH_ELOGIND=1 \
+		TLP_WITH_SYSTEMD=1 \
 		install install-man
 
-	chmod 444 "${D}/usr/share/tlp/defaults.conf" # manpage says this file should not be edited
+	fperms 444 "/usr/share/tlp/defaults.conf" # manpage says this file should not be edited
 	newinitd "${FILESDIR}/tlp.init" tlp
 	keepdir "/var/lib/tlp" # created by Makefile, probably important
 }


### PR DESCRIPTION
The systemd and elogind toggles in the tlp build only toggle
installation of unit file and sleep triggers. There's no need to
conditionally install those per PG#0301.