### PR TITLE
games-emulation/citra: Add dev-util/spirv-headers as a build dependency

### DIFF
--- a/games-emulation/citra/citra-9999.ebuild
+++ b/games-emulation/citra/citra-9999.ebuild
@@ -41,7 +41,9 @@ DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-cpp/cpp-httplib
 	dev-cpp/cpp-jwt
-	dev-cpp/robin-map"
+	dev-cpp/robin-map
+	dev-util/spirv-headers
+"
 REQUIRED_USE="|| ( gui sdl )"
 
 src_unpack() {


### PR DESCRIPTION
`dev-util/spirv-headers` is required for the ebuild to get to the `src_compile()` phase. It will fail otherwise on current git builds of Citra.