### PR TITLE
R-packages.eclass: fix package installation

### DIFF
--- a/eclass/R-packages.eclass
+++ b/eclass/R-packages.eclass
@@ -68,9 +68,11 @@ _movelink() {
 	local source=${1}
 	local dest=${2}
 	if [[ -e "${source}" ]]; then
-		local rp_source="$(realpath ${source} || die)"
-		mv "${rp_source}" "${dest}" || die
-		cp -rsf "${dest}" "${rp_source}" || die
+		local rdir=/usr/$(get_libdir)/R/site-library/${CRAN_PN}
+		local rp_source="${rdir}/${source}"
+		insinto ${rdir}
+		doins -r ${source}
+		ln -s "${rp_source}" "${dest}" || die
 	fi
 }
 
@@ -162,11 +164,7 @@ R-packages_src_install() {
 	fi
 
 	if [[ -e doc ]]; then
-		pushd doc || die
-		for i in *; do
-			_movelink "${i}" "${EDOCDIR}/${i}"
-		done
-		popd || die
+		_movelink doc "${EDOCDIR}"/doc
 	fi
 
 	rm -f LICENSE || die


### PR DESCRIPTION
Instead of creating a symlink R/site-library -> /usr/share/doc
do it otherwise, linking /usr/share/doc -> R/site-library.
This way if nodoc is enabled symlinks won't be broken.

This commit also fixes issues caused by this bug. For example https://bugs.gentoo.org/885331