### PR TITLE
gui-libs/xdg-desktop-portal-hyprland: Added patch for clang, introduced check for >=clang:17

### DIFF
--- a/gui-libs/xdg-desktop-portal-hyprland/files/xdg-desktop-portal-hyprland-1.1.0_fix_clang.patch
+++ b/gui-libs/xdg-desktop-portal-hyprland/files/xdg-desktop-portal-hyprland-1.1.0_fix_clang.patch
@@ -1,0 +1,207 @@
+From 54b5467ec12fb115b537e0c86256226474edf8bb Mon Sep 17 00:00:00 2001
+From: Jan Beich <jbeich@FreeBSD.org>
+Date: Mon, 18 Sep 2023 19:00:21 +0000
+Subject: [PATCH 1/3] build: Unbreak build on FreeBSD (#98)
+
+* helpers: add missing header after 9dfb9e125bf0
+
+src/helpers/MiscFunctions.cpp: In function 'void addHyprlandNotification(const std::string&, float, const std::string&, const std::string&)':
+src/helpers/MiscFunctions.cpp:24:9: error: 'fork' was not declared in this scope
+   24 |     if (fork() == 0)
+      |         ^~~~
+src/helpers/MiscFunctions.cpp:25:9: error: 'execl' was not declared in this scope
+   25 |         execl("/bin/sh", "/bin/sh", "-c", CMD.c_str(), nullptr);
+      |         ^~~~~
+
+* build: add missing dependency for libc++ after 2f48e6550374
+
+ld.lld: error: undefined symbol: pthread_create
+>>> referenced by PortalManager.cpp
+>>>               src/xdg-desktop-portal-hyprland.p/core_PortalManager.cpp.o:(CPortalManager::startEventLoop())
+>>> referenced by PortalManager.cpp
+>>>               src/xdg-desktop-portal-hyprland.p/core_PortalManager.cpp.o:(CPortalManager::startEventLoop())
+---
+ CMakeLists.txt                | 4 +++-
+ src/helpers/MiscFunctions.cpp | 1 +
+ src/meson.build               | 1 +
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e39b72c..44d1689 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,12 +31,14 @@ message(STATUS "Checking deps...")
+ add_subdirectory(subprojects/sdbus-cpp)
+ add_subdirectory(hyprland-share-picker)
+ 
++find_package(Threads REQUIRED)
++
+ find_package(PkgConfig REQUIRED)
+ pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-client wayland-protocols libpipewire-0.3 libspa-0.2 libdrm gbm)
+ 
+ file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
+ add_executable(xdg-desktop-portal-hyprland ${SRCFILES})
+-target_link_libraries(xdg-desktop-portal-hyprland PRIVATE rt sdbus-c++ PkgConfig::deps)
++target_link_libraries(xdg-desktop-portal-hyprland PRIVATE rt sdbus-c++ Threads::Threads PkgConfig::deps)
+ 
+ # protocols
+ find_program(WaylandScanner NAMES wayland-scanner)
+diff --git a/src/helpers/MiscFunctions.cpp b/src/helpers/MiscFunctions.cpp
+index da05ee6..353c8f0 100644
+--- a/src/helpers/MiscFunctions.cpp
++++ b/src/helpers/MiscFunctions.cpp
+@@ -1,5 +1,6 @@
+ #include "MiscFunctions.hpp"
+ #include <memory>
++#include <unistd.h>
+ #include "../helpers/Log.hpp"
+ 
+ std::string execAndGet(const char* cmd) {
+diff --git a/src/meson.build b/src/meson.build
+index 444d3bd..c3d3735 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -8,6 +8,7 @@ executable('xdg-desktop-portal-hyprland',
+     dependency('libdrm'),
+     dependency('libpipewire-0.3'),
+     dependency('sdbus-c++'),
++    dependency('threads'),
+     dependency('wayland-client'),
+   ],
+   include_directories: inc,
+-- 
+2.42.0
+
+From b6e1732fdac623638dbc12db00e10ac4b5bd791f Mon Sep 17 00:00:00 2001
+From: vaxerski <43317083+vaxerski@users.noreply.github.com>
+Date: Fri, 22 Sep 2023 19:28:47 +0100
+Subject: [PATCH 2/3] picker: start on index 0
+
+---
+ hyprland-share-picker/mainpicker.ui | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hyprland-share-picker/mainpicker.ui b/hyprland-share-picker/mainpicker.ui
+index c14d1d6..95a3c65 100644
+--- a/hyprland-share-picker/mainpicker.ui
++++ b/hyprland-share-picker/mainpicker.ui
+@@ -66,7 +66,7 @@
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="currentIndex">
+-     <number>1</number>
++     <number>0</number>
+     </property>
+     <widget class="QWidget" name="screens">
+      <attribute name="title">
+-- 
+2.42.0
+
+From f9461b0b7d3071347390feee534638555ff76c7d Mon Sep 17 00:00:00 2001
+From: Rudolchr <72916442+Rudolchr@users.noreply.github.com>
+Date: Tue, 26 Sep 2023 23:23:02 +0200
+Subject: [PATCH 3/3] build: Fix build when using clang (#100)
+
+* Add -Wno-address-of-temporary to allow taking an address of temporary like -fpermissive does for gcc
+
+* Make some implicit casts explicit
+
+* Implement the wl_array_for_each macro inline as clang does not like to handle it's implicit typecast
+
+* Removed unecessary include that was automatically added by the ide
+
+* Replaced reinterpret_cast's with c-style casts
+---
+ meson.build                |  5 +++--
+ src/core/PortalManager.cpp |  3 ++-
+ src/portals/Screencopy.cpp | 19 ++++++++++---------
+ 3 files changed, 15 insertions(+), 12 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 77c1a80..2fff319 100644
+--- a/meson.build
++++ b/meson.build
+@@ -25,10 +25,11 @@ endif
+ add_project_arguments(cpp_compiler.get_supported_arguments([
+   '-Wno-missing-field-initializers',
+   '-Wno-narrowing',
+-	'-Wno-pointer-arith',
++  '-Wno-pointer-arith',
+   '-Wno-unused-parameter',
+   '-Wno-unused-value',
+-	'-fpermissive'
++  '-fpermissive',
++  '-Wno-address-of-temporary'
+ ]), language: 'cpp')
+ 
+ conf_data = configuration_data()
+diff --git a/src/core/PortalManager.cpp b/src/core/PortalManager.cpp
+index d56ebe0..a03da31 100644
+--- a/src/core/PortalManager.cpp
++++ b/src/core/PortalManager.cpp
+@@ -169,7 +169,8 @@ static void dmabufFeedbackTrancheFormats(void* data, zwp_linux_dmabuf_feedback_v
+     uint32_t  n_modifiers = g_pPortalManager->m_sWaylandConnection.dma.formatTableSize / sizeof(struct fm_entry);
+     fm_entry* fm_entry    = (struct fm_entry*)g_pPortalManager->m_sWaylandConnection.dma.formatTable;
+     uint16_t* idx;
+-    wl_array_for_each(idx, indices) {
++
++    for (idx = (uint16_t*)indices->data; (const char*)idx < (const char*)indices->data + indices->size; idx++) {
+         if (*idx >= n_modifiers)
+             continue;
+ 
+diff --git a/src/portals/Screencopy.cpp b/src/portals/Screencopy.cpp
+index c5b234c..d69d353 100644
+--- a/src/portals/Screencopy.cpp
++++ b/src/portals/Screencopy.cpp
+@@ -781,7 +781,7 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param)
+             const spa_pod* pod_modifier = &prop_modifier->value;
+ 
+             uint32_t       n_modifiers = SPA_POD_CHOICE_N_VALUES(pod_modifier) - 1;
+-            uint64_t*      modifiers   = SPA_POD_CHOICE_VALUES(pod_modifier);
++            uint64_t*      modifiers   = (uint64_t*)SPA_POD_CHOICE_VALUES(pod_modifier);
+             modifiers++;
+             uint32_t         flags = GBM_BO_USE_RENDERING;
+             uint64_t         modifier;
+@@ -853,14 +853,15 @@ static void pwStreamParamChanged(void* data, uint32_t id, const spa_pod* param)
+ 
+     params[0] = build_buffer(&dynBuilder[0].b, blocks, PSTREAM->pSession->sharingData.frameInfoSHM.size, PSTREAM->pSession->sharingData.frameInfoSHM.stride, data_type);
+ 
+-    params[1] = spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header), SPA_PARAM_META_size,
+-                                           SPA_POD_Int(sizeof(struct spa_meta_header)));
++    params[1] = (const spa_pod*)spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_Header),
++                                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_header)));
+ 
+-    params[2] = spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoTransform),
+-                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform)));
++    params[2] = (const spa_pod*)spa_pod_builder_add_object(&dynBuilder[1].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoTransform),
++                                                           SPA_PARAM_META_size, SPA_POD_Int(sizeof(struct spa_meta_videotransform)));
+ 
+-    params[3] = spa_pod_builder_add_object(&dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
+-                                           SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4));
++    params[3] = (const spa_pod*)spa_pod_builder_add_object(
++        &dynBuilder[2].b, SPA_TYPE_OBJECT_ParamMeta, SPA_PARAM_Meta, SPA_PARAM_META_type, SPA_POD_Id(SPA_META_VideoDamage), SPA_PARAM_META_size,
++        SPA_POD_CHOICE_RANGE_Int(sizeof(struct spa_meta_region) * 4, sizeof(struct spa_meta_region) * 1, sizeof(struct spa_meta_region) * 4));
+ 
+     pw_stream_update_params(PSTREAM->stream, params, 4);
+     spa_pod_dynamic_builder_clean(&dynBuilder[0]);
+@@ -1061,7 +1062,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
+ 
+         paramCount = 2;
+         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoDMA.fmt), stream->pSession->sharingData.frameInfoDMA.w,
+-                                 stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
++                                  stream->pSession->sharingData.frameInfoDMA.h, stream->pSession->sharingData.framerate, modifiers, modCount);
+         assert(params[0] != NULL);
+         params[1] = build_format(b[1], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
+                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
+@@ -1071,7 +1072,7 @@ uint32_t CPipewireConnection::buildFormatsFor(spa_pod_builder* b[2], const spa_p
+ 
+         paramCount = 1;
+         params[0]  = build_format(b[0], pwFromDrmFourcc(stream->pSession->sharingData.frameInfoSHM.fmt), stream->pSession->sharingData.frameInfoSHM.w,
+-                                 stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
++                                  stream->pSession->sharingData.frameInfoSHM.h, stream->pSession->sharingData.framerate, NULL, 0);
+     }
+ 
+     return paramCount;
+-- 
+2.42.0
+

--- a/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-1.1.0.ebuild
+++ b/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-1.1.0.ebuild
@@ -61,9 +61,15 @@ pkg_setup() {
 		if [[ ${STDLIBVER} -lt 13 ]]; then
 			die "XDPH requires >=sys-devel/gcc-13.0.0 to build"
 		fi
-	else
-		die "XDPH 1.1.0 won't build with clang.\
-		See: https://github.com/hyprwm/xdg-desktop-portal-hyprland/issues/81";
+	elif [[ $(clang-major-version) -lt 17 ]] ; then
+		die "XDPH-1.1.0 requires >= sys-devel/clang-17.0.1 to build"
+	fi
+}
+
+src_prepare() {
+	if tc-is-clang ; then
+		eapply "${FILESDIR}/xdg-desktop-portal-hyprland-1.1.0_fix_clang.patch"
+		default
 	fi
 }
 

--- a/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-1.1.0.ebuild
+++ b/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-1.1.0.ebuild
@@ -67,10 +67,8 @@ pkg_setup() {
 }
 
 src_prepare() {
-	if tc-is-clang ; then
-		eapply "${FILESDIR}/xdg-desktop-portal-hyprland-1.1.0_fix_clang.patch"
-		default
-	fi
+	eapply "${FILESDIR}/xdg-desktop-portal-hyprland-1.1.0_fix_clang.patch"
+	default
 }
 
 src_compile() {

--- a/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-9999.ebuild
+++ b/gui-libs/xdg-desktop-portal-hyprland/xdg-desktop-portal-hyprland-9999.ebuild
@@ -61,9 +61,8 @@ pkg_setup() {
 		if [[ ${STDLIBVER} -lt 13 ]]; then
 			die "XDPH requires >=sys-devel/gcc-13.0.0 to build"
 		fi
-	else
-		die "XDPH 1.1.0 won't build with clang.\
-		See: https://github.com/hyprwm/xdg-desktop-portal-hyprland/issues/81";
+	elif [[ $(clang-major-version) -lt 17 ]] ; then
+		die "XDPH requires >= sys-devel/clang-17.0.1 to build"
 	fi
 }
 


### PR DESCRIPTION
The build issues with clang have been resolved upstream in the following commits:
https://github.com/hyprwm/xdg-desktop-portal-hyprland/commit/54b5467ec12fb115b537e0c86256226474edf8bb
https://github.com/hyprwm/xdg-desktop-portal-hyprland/commit/f9461b0b7d3071347390feee534638555ff76c7d

I combined the last 3 commits into a patch and added it to the ebuild for 1.1.0 if the user is using clang.
I also added a check for >=clang-17.0.1 as it failed to build with clang-16.0.6 while testing in a chroot.

I would be happy about any feedback or helping with further testing that is required.