### PR TITLE
app-containers/waydroid: Add new runtime dependency

### DIFF
--- a/app-containers/waydroid/waydroid-1.4.0.ebuild
+++ b/app-containers/waydroid/waydroid-1.4.0.ebuild
@@ -24,6 +24,7 @@ RDEPEND="
 		dev-python/pygobject[${PYTHON_USEDEP}]
 		>=dev-python/gbinder-1.1.1[${PYTHON_USEDEP}]
 		>=dev-python/pyclip-0.7.0[wayland,${PYTHON_USEDEP}]
+		dev-python/dbus-python[${PYTHON_USEDEP}]
 	')
 	net-firewall/nftables[modern-kernel]
 	net-dns/dnsmasq


### PR DESCRIPTION
Fixes a ModuleNotFoundError seen when attempting to initialze Waydroid.

Signed-off-by: Sebastian France <MagelessMayhem@protonmail.com>
