### PR TITLE
[media-fonts/lato] fix link

### DIFF
--- a/media-fonts/lato/lato-2.ebuild
+++ b/media-fonts/lato/lato-2.ebuild
@@ -7,7 +7,7 @@ inherit font
 
 DESCRIPTION="Lato font"
 HOMEPAGE="https://www.latofonts.com/"
-SRC_URI="https://www.latofonts.com/download/Lato2OFL.zip -> ${P}.zip"
+SRC_URI="https://www.latofonts.com/files/Lato2OFL.zip -> ${P}.zip"
 
 LICENSE="OFL-1.1"
 SLOT="0"


### PR DESCRIPTION
according to the cask with the same name in Homebrew. 
https://github.com/Homebrew/homebrew-cask-fonts/blob/master/Casks/font-lato.rb#L5C8-L5C52