### PR TITLE
Added required runtime dependency.

### DIFF
--- a/net-p2p/feather/feather-2.6.1.ebuild
+++ b/net-p2p/feather/feather-2.6.1.ebuild
@@ -64,6 +64,7 @@ RDEPEND="
 	${DEPEND}
 	net-vpn/tor
 	xmrig? ( net-misc/xmrig )
+	qrcode? ( media-libs/zxing-cpp )
 "
 BDEPEND="
 	virtual/pkgconfig


### PR DESCRIPTION
Build fails without `media-libs/zxing-cpp` installed.