### PR TITLE
app-misc/cpufetch: add ~arm64 and ~ppc64 keywords

### DIFF
--- a/app-misc/cpufetch/cpufetch-1.04.ebuild
+++ b/app-misc/cpufetch/cpufetch-1.04.ebuild
@@ -12,7 +12,7 @@ S="${WORKDIR}/${PN}-${PV}"
 
 LICENSE="GPL-2+"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64 ~ppc64"
 
 src_prepare() {
 	default


### PR DESCRIPTION
Works fine on both.