### PR TITLE
Enable keyring feature of dev-libs/qtkeychain for net-im/nheko

### DIFF
--- a/net-im/nheko/nheko-0.11.3-r1.ebuild
+++ b/net-im/nheko/nheko-0.11.3-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,7 @@ COMMON_DEPEND="
 	dev-libs/libfmt:=
 	>=dev-libs/mtxclient-0.9.0:=
 	dev-libs/olm
-	>=dev-libs/qtkeychain-0.12.0:=[qt5]
+	>=dev-libs/qtkeychain-0.12.0:=[keyring,qt5]
 	dev-libs/spdlog:=
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5

--- a/net-im/nheko/nheko-0.11.3-r2.ebuild
+++ b/net-im/nheko/nheko-0.11.3-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Gentoo Authors
+# Copyright 2020-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -26,7 +26,7 @@ COMMON_DEPEND="
 	dev-libs/libfmt:=
 	>=dev-libs/mtxclient-0.9.0:=
 	dev-libs/olm
-	>=dev-libs/qtkeychain-0.12.0:=[qt5]
+	>=dev-libs/qtkeychain-0.12.0:=[keyring,qt5]
 	dev-libs/spdlog:=
 	dev-qt/qtcore:5
 	dev-qt/qtdbus:5

--- a/net-im/nheko/nheko-9999.ebuild
+++ b/net-im/nheko/nheko-9999.ebuild
@@ -33,7 +33,7 @@ RDEPEND="
 	dev-libs/libfmt:=
 	dev-libs/olm
 	>=dev-libs/openssl-1.1.0:=
-	>=dev-libs/qtkeychain-0.14.1-r1:=[qt6]
+	>=dev-libs/qtkeychain-0.14.1-r1:=[keyring,qt6]
 	>=dev-libs/re2-0.2022.04.01:=
 	dev-libs/spdlog:=
 	>=dev-qt/kdsingleapplication-1.1.0:=[qt6]


### PR DESCRIPTION
The requirement is mentioned in the nheko readme
