### PR TITLE
Added support for arm64.

### DIFF
--- a/net-p2p/yggdrasil-go/yggdrasil-go-0.5.5.ebuild
+++ b/net-p2p/yggdrasil-go/yggdrasil-go-0.5.5.ebuild
@@ -14,7 +14,7 @@ SRC_URI="
 
 LICENSE="LGPL-3 MIT Apache-2.0 BSD ZLIB"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~arm64"
 RESTRICT="mirror"
 
 DEPEND="


### PR DESCRIPTION
This package compiles and runs just fine on a Raspberry Pi 4. The upstream supports arm64 as well.