### PR TITLE
x11-wm/firefox-i3-workspaces: Fix description

### DIFF
--- a/x11-wm/firefox-i3-workspaces/firefox-i3-workspaces-0.10.ebuild
+++ b/x11-wm/firefox-i3-workspaces/firefox-i3-workspaces-0.10.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DESCRIPTION="Restore Firefox windowS to correct i3 workspaceS, helper web extension is needed"
+DESCRIPTION="Restore Firefox windows to correct i3 workspaces, helper web extension is needed"
 HOMEPAGE="https://github.com/yurikhan/firefox-i3-workspaces"
 SRC_URI="https://github.com/yurikhan/$PN/archive/refs/tags/$PV.tar.gz"
 


### PR DESCRIPTION
Replaced two "s" letters that were written in upper-case with their lower-case counterparts.