### PR TITLE
net-im/vesktop-bin: fix typo in desktop file

### DIFF
--- a/net-im/vesktop-bin/files/vesktop-bin.desktop
+++ b/net-im/vesktop-bin/files/vesktop-bin.desktop
@@ -6,5 +6,5 @@ Type=Application
 Exec=/usr/bin/vesktop-bin
 Icon=vesktop-bin
 Categories=Network;InstantMessaging;
-StartupWMClass=Vesktop
+StartupWMClass=vesktop
 Keywords=discord;vencord;


### PR DESCRIPTION
Sorry for making another pull request but it seems that I made a typo while editing the desktop file yesterday and personal changes weren't overwritten.
Thus, this pull request intends to fix my own typo in the `StartupWMClass` entry of the desktop file.