### PR TITLE
media-sound/youtube-music-bin: fix missing runtime dependencies

### DIFF
--- a/media-sound/youtube-music-bin/youtube-music-bin-3.3.6.ebuild
+++ b/media-sound/youtube-music-bin/youtube-music-bin-3.3.6.ebuild
@@ -24,6 +24,24 @@ RDEPEND="
 	x11-libs/gtk+:3
 	x11-libs/libnotify
 	x11-libs/libXtst
+	dev-libs/expat
+	dev-libs/glib:2
+	dev-libs/nspr
+	media-libs/alsa-lib
+	media-libs/mesa
+	net-print/cups
+	sys-apps/dbus
+	x11-libs/cairo
+	x11-libs/libdrm
+	x11-libs/libX11
+	x11-libs/libxcb
+	x11-libs/libXcomposite
+	x11-libs/libXdamage
+	x11-libs/libXext
+	x11-libs/libXfixes
+	x11-libs/libxkbcommon
+	x11-libs/libXrandr
+	x11-libs/pango
 "
 
 RESTRICT="mirror strip"


### PR DESCRIPTION
This pull request intends to add missing runtime dependencies to the `youtube-music-bin` package.

Closes: https://bugs.gentoo.org/931230