### PR TITLE
net-vpn/mullvadvpn-app: Add gui to /usr/bin

### DIFF
--- a/net-vpn/mullvadvpn-app/mullvadvpn-app-2024.3.ebuild
+++ b/net-vpn/mullvadvpn-app/mullvadvpn-app-2024.3.ebuild
@@ -36,6 +36,8 @@ RDEPEND="
 QA_PREBUILT="*"
 
 src_install() {
+	sed -i "s|SCRIPT_DIR=.*|SCRIPT_DIR=\"/opt/Mullvad VPN/\"|g" "${S}"/opt/Mullvad\ VPN/mullvad-vpn
+
 	# Using doins -r would strip executable bits from all binaries
 	cp -pPR "${S}"/opt "${D}"/ || die "Failed to copy files"
 	fperms +x "/opt/Mullvad VPN/chrome_crashpad_handler"
@@ -47,6 +49,7 @@ src_install() {
 	dobin "${S}"/usr/bin/mullvad
 	dobin "${S}"/usr/bin/mullvad-daemon
 	dobin "${S}"/usr/bin/mullvad-exclude
+	dosym "../../opt/Mullvad VPN/mullvad-vpn" /usr/bin/mullvad-vpn
 	dosym "../../opt/Mullvad VPN/resources/mullvad-problem-report" /usr/bin/mullvad-problem-report
 
 	# mullvad-exclude uses cgroups to manage exclusions, which requires root permissions, but is


### PR DESCRIPTION
The previous ebuild installed the cli components to /usr/bin but did not install the gui, only a desktop file. The changes below install the gui application alongside the cli components instead of having to manually create a symbolic link.

The sed portion is necessary as the launch script does not work unless inside the application directory, in this case /opt/Mullvad VPN. By specifying the 'SCRIPT_DIR' the application launches fine.