### PR TITLE
MISSING SimpleXML REQUIRED - SimpleXML is required for XML operations. Updated ebuild to include missing USE dep

### DIFF
--- a/app-benchmarks/phoronix-test-suite/phoronix-test-suite-9999.ebuild
+++ b/app-benchmarks/phoronix-test-suite/phoronix-test-suite-9999.ebuild
@@ -20,7 +20,7 @@ IUSE="sdl"
 RDEPEND="${DEPEND}
 		app-arch/p7zip
 		media-libs/libpng
-		>=dev-lang/php-5.3[cli,curl,gd,posix,pcntl,sockets,ssl,truetype,xml,zip,zlib]
+		>=dev-lang/php-5.3[cli,curl,gd,posix,pcntl,simplexml,sockets,ssl,truetype,xml,zip,zlib]
 		www-servers/apache
 		x11-base/xorg-server
 		sdl? (


### PR DESCRIPTION
Missing SimpleXML dep