### PR TITLE
Make the ags work

### DIFF
--- a/gui-apps/aylurs-gtk-shell/aylurs-gtk-shell-1.8.2.ebuild
+++ b/gui-apps/aylurs-gtk-shell/aylurs-gtk-shell-1.8.2.ebuild
@@ -39,7 +39,9 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 "
-
+PATCHES=(
+	"${FILESDIR}/${P}-correct_bin_src.patch"
+)
 BUILD_DIR="${S}/build"
 
 src_prepare() {

--- a/gui-apps/aylurs-gtk-shell/files/aylurs-gtk-shell-1.8.2-correct_bin_src.patch
+++ b/gui-apps/aylurs-gtk-shell/files/aylurs-gtk-shell-1.8.2-correct_bin_src.patch
@@ -1,0 +1,13 @@
+#Patch post_install.sh to make the symbole link point to the correct path instead of a path inside build image
+
+--- a/post_install.sh
++++ b/post_install.sh
+@@ -7,7 +7,7 @@ APP_ID=$4
+ 
+ mkdir -p $BIN_DIR
+ 
+-BIN_SRC="$PKGDATA_DIR/$APP_ID"
++BIN_SRC="$2/$APP_ID"
+ BIN_DEST="$BIN_DIR/ags"
+ ln -s -f $BIN_SRC $BIN_DEST
+ 


### PR DESCRIPTION
Currently after install this package the `/usr/bin/ags` is soft link to a place inside the image which will be removed after portage install and make ags unusable this change just manually create a link point to the correct location after the `src_install`