### PR TITLE
acct-user/ollama: simple tweak for the daemon to work

### DIFF
--- a/acct-user/ollama/ollama-1.ebuild
+++ b/acct-user/ollama/ollama-1.ebuild
@@ -8,6 +8,7 @@ inherit acct-user
 DESCRIPTION="A user for ollama"
 ACCT_USER_ID=-1
 ACCT_USER_HOME=/var/lib/ollama
+ACCT_USER_SHELL=/bin/false
 ACCT_USER_HOME_PERMS=0700
 ACCT_USER_GROUPS=( ollama )
 


### PR DESCRIPTION
@vitaly-zdanevich @antecrescent Hello again, this time I'm submitting a simple tweak because of the ollama daemon, it will not run the `ollama serve` command if the ollama user's shell is set to /sbin/nologin. I change it so it uses /bin/false because the official docs recommend that and voila the daemon works as intended
https://github.com/ollama/ollama/blob/main/docs/linux.md#adding-ollama-as-a-startup-service-recommended