### PR TITLE
dev-debug/gdb-dashboard: enable py3.12

### DIFF
--- a/dev-debug/gdb-dashboard/gdb-dashboard-0.17.2.ebuild
+++ b/dev-debug/gdb-dashboard/gdb-dashboard-0.17.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{10..12} )
 
 inherit python-single-r1 optfeature wrapper
 
@@ -21,7 +21,10 @@ fi
 LICENSE="MIT"
 SLOT="0"
 
-RDEPEND="dev-debug/gdb[python]"
+RDEPEND="
+	dev-debug/gdb[python]
+	${PYTHON_DEPS}
+"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 pkg_setup() {


### PR DESCRIPTION
This change adds python 3.12 support for users of this package that want to upgrade their systems to python 3.12.

`pkgcheck scan --net` also told me to add `RDEPEND="${PYTHON_DEPS}"`