### PR TITLE
gui-apps/wbg: Improve USE flags

### DIFF
--- a/gui-apps/wbg/metadata.xml
+++ b/gui-apps/wbg/metadata.xml
@@ -5,6 +5,9 @@
 		<name>Leonardo Hernández Hernández</name>
 		<email>leohdz172@proton.me</email>
 	</maintainer>
+	<use>
+		<flag name="system-nanosvg">Use system-installed nanosvg instead of bundled version</flag>
+	</use>
 	<longdescription lang="en">
 		Super simple wallpaper application for Wayland compositors implementing the layer-shell protocol.
 		Wbg takes a single command line argument: a path to an image file. This image is displayed scaled-to-fit on all monitors.

--- a/gui-apps/wbg/wbg-1.0.2.ebuild
+++ b/gui-apps/wbg/wbg-1.0.2.ebuild
@@ -15,7 +15,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
-IUSE="png jpeg"
+IUSE="+png jpeg"
 REQUIRED_USE="|| ( png jpeg )"
 
 DEPEND="

--- a/gui-apps/wbg/wbg-1.1.0.ebuild
+++ b/gui-apps/wbg/wbg-1.1.0.ebuild
@@ -15,7 +15,7 @@ LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64"
 
-IUSE="png jpeg webp"
+IUSE="+png jpeg webp"
 REQUIRED_USE="|| ( png jpeg webp )"
 
 DEPEND="

--- a/gui-apps/wbg/wbg-1.2.0.ebuild
+++ b/gui-apps/wbg/wbg-1.2.0.ebuild
@@ -20,7 +20,7 @@ HOMEPAGE="https://codeberg.org/dnkl/wbg"
 # ZLIB for nanosvg
 LICENSE="MIT ZLIB"
 SLOT="0"
-IUSE="png jpeg webp"
+IUSE="+png jpeg webp"
 
 RDEPEND="
 	dev-libs/wayland

--- a/gui-apps/wbg/wbg-9999.ebuild
+++ b/gui-apps/wbg/wbg-9999.ebuild
@@ -3,16 +3,9 @@
 
 EAPI=8
 
-inherit meson
+inherit meson git-r3
 
-if [[ ${PV} == *9999* ]]; then
-	EGIT_REPO_URI="https://codeberg.org/dnkl/wbg.git"
-	inherit git-r3
-else
-	SRC_URI="https://codeberg.org/dnkl/wbg/archive/${PV}.tar.gz  -> ${P}.tar.gz"
-	KEYWORDS="~amd64"
-	S="${WORKDIR}/${PN}"
-fi
+EGIT_REPO_URI="https://codeberg.org/dnkl/wbg.git"
 
 DESCRIPTION="Super simple wallpaper application"
 HOMEPAGE="https://codeberg.org/dnkl/wbg"
@@ -20,7 +13,12 @@ HOMEPAGE="https://codeberg.org/dnkl/wbg"
 # ZLIB for nanosvg
 LICENSE="MIT ZLIB"
 SLOT="0"
-IUSE="jpeg jpegxl png webp"
+IUSE="jpeg jpegxl png webp +svg system-nanosvg"
+
+REQUIRED_USE="
+	|| ( jpeg jpegxl png webp svg )
+	system-nanosvg? ( svg )
+"
 
 RDEPEND="
 	dev-libs/wayland
@@ -29,6 +27,7 @@ RDEPEND="
 	jpegxl? ( media-libs/libjxl:= )
 	png? ( media-libs/libpng:= )
 	webp? ( media-libs/libwebp:= )
+	system-nanosvg? ( media-libs/nanosvg:= )
 "
 DEPEND="
 	${RDEPEND}
@@ -46,7 +45,8 @@ src_configure() {
 		$(meson_feature jpegxl jxl)
 		$(meson_feature png)
 		$(meson_feature webp)
-		-Dsvg=true
+		$(meson_feature system-nanosvg)
+		$(meson_use svg)
 	)
 
 	meson_src_configure


### PR DESCRIPTION
- Ensure at least one USE flag is selected by default
- Make svg support switchable and default enabled for 9999
- Add system-nanosvg for upstream feature support
- Require svg for system-nanosvg
- Add metadata and explanation for system-nanosvg
- Make png default enabled for older versions because pkgcheck complains