### PR TITLE
app-misc/xplr: fix dobin failure (nonexistent path)

### DIFF
--- a/app-misc/xplr/xplr-0.21.3.ebuild
+++ b/app-misc/xplr/xplr-0.21.3.ebuild
@@ -248,7 +248,7 @@ src_compile() {
 src_install() {
 	dodoc README.md
 
-	dobin target/$(usex debug debug release)/xplr
+	dobin $(cargo_target_dir)/xplr
 	newicon -s 16 assets/icon/${PN}16.png ${PN}.png
 	newicon -s 32 assets/icon/${PN}32.png ${PN}.png
 	newicon -s 64 assets/icon/${PN}64.png ${PN}.png

--- a/app-misc/xplr/xplr-0.21.3.ebuild
+++ b/app-misc/xplr/xplr-0.21.3.ebuild
@@ -248,12 +248,12 @@ src_compile() {
 src_install() {
 	dodoc README.md
 
-	dobin $(cargo_target_dir)/xplr
-	newicon -s 16 assets/icon/${PN}16.png ${PN}.png
-	newicon -s 32 assets/icon/${PN}32.png ${PN}.png
-	newicon -s 64 assets/icon/${PN}64.png ${PN}.png
-	newicon -s 128 assets/icon/${PN}128.png ${PN}.png
-	doicon -s scalable assets/icon/${PN}.svg
+	dobin "$(cargo_target_dir)/xplr"
+	newicon -s 16 "assets/icon/${PN}16.png" "${PN}.png"
+	newicon -s 32 "assets/icon/${PN}32.png" "${PN}.png"
+	newicon -s 64 "assets/icon/${PN}64.png" "${PN}.png"
+	newicon -s 128 "assets/icon/${PN}128.png" "${PN}.png"
+	doicon -s scalable "assets/icon/${PN}.svg"
 	domenu assets/desktop/xplr.desktop
 }
 


### PR DESCRIPTION
In src_install(), the dobin line causes an installation failure:
```
!!! dobin: target/release/xplr does not exist
```

Using cargo_target_dir() from the cargo eclass resolves the installation failure.

I also quoted some variables while here.