### PR TITLE
net-im/vesktop-bin: remove unused dependency

### DIFF
--- a/net-im/vesktop-bin/vesktop-bin-1.5.3.ebuild
+++ b/net-im/vesktop-bin/vesktop-bin-1.5.3.ebuild
@@ -26,7 +26,6 @@ RESTRICT="bindist mirror strip test"
 
 DEPEND="
 	libnotify? ( x11-libs/libnotify )
-	app-crypt/libsecret
 	app-accessibility/at-spi2-core
 	dev-libs/expat
 	dev-libs/glib


### PR DESCRIPTION
Inspired by https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=b460063c95b80b12995897ecb972d1f03689129f