### PR TITLE
dev-cpp/wt-4.11.0: Get ride of restriction for boost.

### DIFF
--- a/dev-cpp/wt/wt-4.11.0.ebuild
+++ b/dev-cpp/wt/wt-4.11.0.ebuild
@@ -20,7 +20,7 @@ DEPEND="
 	opengl? ( virtual/opengl )
 	postgres? ( dev-db/postgresql )
 	ssl? ( dev-libs/openssl )
-	<dev-libs/boost-1.85.0:=
+	dev-libs/boost:=
 	media-libs/libharu
 	media-gfx/graphicsmagick[jpeg,png]
 	x11-libs/pango


### PR DESCRIPTION
Successfully built with 1.85 & 1.86.