### PR TITLE
dev-cpp/wt: add pango useflag, enabled by default.

### DIFF
--- a/dev-cpp/wt/metadata.xml
+++ b/dev-cpp/wt/metadata.xml
@@ -5,6 +5,9 @@
 		<email>davidroman96@gmail.com</email>
 		<name>David Roman</name>
 	</maintainer>
+	<use>
+		<flag name="pango">Enable <pkg>x11-libs/pango</pkg>, wich is used for improved font support (WPdfImage and WRasterImage)</flag>
+	</use>
 	<upstream>
 		<remote-id type="github">emweb/wt</remote-id>
 	</upstream>

--- a/dev-cpp/wt/wt-4.11.0.ebuild
+++ b/dev-cpp/wt/wt-4.11.0.ebuild
@@ -12,18 +12,18 @@ SRC_URI="https://github.com/emweb/wt/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="doc firebird mysql opengl pdf postgres ssl"
+IUSE="doc firebird mysql opengl +pango pdf postgres ssl"
 
 DEPEND="
 	firebird? ( dev-db/firebird )
 	mysql? ( virtual/mysql )
 	opengl? ( virtual/opengl )
+	pango? ( x11-libs/pango )
 	postgres? ( dev-db/postgresql )
 	ssl? ( dev-libs/openssl )
 	dev-libs/boost:=
 	media-libs/libharu
 	media-gfx/graphicsmagick[jpeg,png]
-	x11-libs/pango
 	sys-libs/zlib
 "
 RDEPEND="${DEPEND}"
@@ -50,7 +50,7 @@ src_configure() {
 		-DDOCUMENTATION_DESTINATION="share/doc/${PF}"
 		-DENABLE_SSL=$(usex ssl)
 		-DENABLE_HARU=$(usex pdf)
-		-DENABLE_PANGO=ON
+		-DENABLE_PANGO=$(usex pango)
 		-DENABLE_SQLITE=ON
 		-DENABLE_POSTGRES=$(usex postgres)
 		-DENABLE_FIREBIRD=$(usex firebird)


### PR DESCRIPTION
Allow to reduce dependencies. Pango may not be necessary for some use cases of wt.