### PR TITLE
dev-cpp/wt: use subslots

### DIFF
--- a/dev-cpp/wt/wt-4.11.0.ebuild
+++ b/dev-cpp/wt/wt-4.11.0.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://www.webtoolkit.eu/wt https://github.com/emweb/wt"
 SRC_URI="https://github.com/emweb/wt/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
-SLOT="0"
+SLOT="0/${PV}"
 KEYWORDS="~amd64"
 IUSE="doc firebird mysql opengl +pango pdf postgres ssl"
 

--- a/dev-cpp/wt/wt-4.11.1.ebuild
+++ b/dev-cpp/wt/wt-4.11.1.ebuild
@@ -10,7 +10,7 @@ HOMEPAGE="https://www.webtoolkit.eu/wt https://github.com/emweb/wt"
 SRC_URI="https://github.com/emweb/wt/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
-SLOT="0"
+SLOT="0/${PV}"
 KEYWORDS="~amd64"
 IUSE="doc firebird mysql opengl +pango pdf postgres ssl"
 


### PR DESCRIPTION
To prevent using preserved-lib due to the soversion name of the library files, use subslots.