### PR TITLE
app-office/obsidian: Add `wayland` USE flag

### DIFF
--- a/app-office/obsidian/obsidian-1.6.7.ebuild
+++ b/app-office/obsidian/obsidian-1.6.7.ebuild
@@ -34,7 +34,7 @@ S="${WORKDIR}"
 LICENSE="Obsidian-EULA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="appindicator"
+IUSE="appindicator wayland"
 RESTRICT="mirror strip bindist"
 
 RDEPEND="
@@ -158,7 +158,9 @@ src_install() {
 	fi
 
 	domenu usr/share/applications/obsidian.desktop
-	domenu usr/share/applications/obsidian-wayland.desktop
+	if use wayland; then
+		domenu usr/share/applications/obsidian-wayland.desktop
+	fi
 
 	for size in 16 32 48 64 128 256 512; do
 		doicon --size ${size} usr/share/icons/hicolor/${size}x${size}/apps/${PN}.png

--- a/app-office/obsidian/obsidian-1.7.4.ebuild
+++ b/app-office/obsidian/obsidian-1.7.4.ebuild
@@ -34,7 +34,7 @@ S="${WORKDIR}"
 LICENSE="Obsidian-EULA"
 SLOT="0"
 KEYWORDS="~amd64 ~arm64"
-IUSE="appindicator"
+IUSE="appindicator wayland"
 RESTRICT="mirror strip bindist"
 
 RDEPEND="
@@ -158,7 +158,9 @@ src_install() {
 	fi
 
 	domenu usr/share/applications/obsidian.desktop
-	domenu usr/share/applications/obsidian-wayland.desktop
+	if use wayland; then
+		domenu usr/share/applications/obsidian-wayland.desktop
+	fi
 
 	for size in 16 32 48 64 128 256 512; do
 		doicon --size ${size} usr/share/icons/hicolor/${size}x${size}/apps/${PN}.png


### PR DESCRIPTION
This pull request adds a new `wayland` USE flag for Obsidian.

When this flag is disabled, the Obsidian Wayland desktop entry is not created.
Previously this desktop entry was always created, even when being installed on a system that doesn't use Wayland.

This is my first time contributing to Guru or any other Gentoo repository, so please correct me if I missed something I should have done.