### PR TITLE
media-gfx/bambustudio-bin: add osmesa USE requirement to mesa dependency

### DIFF
--- a/media-gfx/bambustudio-bin/bambustudio-bin-01.10.01.50.ebuild
+++ b/media-gfx/bambustudio-bin/bambustudio-bin-01.10.01.50.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	media-libs/glew:0=
 	>=media-libs/glm-0.9.9.1
 	media-libs/gstreamer
-	media-libs/mesa[X(+)]
+	media-libs/mesa[X(+),osmesa]
 	net-libs/libsoup:3.0=
 	net-libs/webkit-gtk:4.1/0
 	>=sci-libs/opencascade-7.3.0:0=


### PR DESCRIPTION
This avoids this error at launch:
"/opt/bambustudio-bin/bin/bambu-studio: error while loading shared libraries: libOSMesa.so.8: cannot open shared object file: No such file or directory"