### PR TITLE
pyside6 dependency fix for both ProtonUp-Qt ebuilds

### DIFF
--- a/games-util/ProtonUp-Qt/ProtonUp-Qt-2.9.2.ebuild
+++ b/games-util/ProtonUp-Qt/ProtonUp-Qt-2.9.2.ebuild
@@ -22,7 +22,7 @@ KEYWORDS="~amd64"
 
 RDEPEND="dev-python/steam
 	dev-python/requests
-	dev-python/pyside6[designer(+)]
+	dev-python/pyside6[gui,uitools,widgets]
 	dev-python/vdf
 	dev-python/pyxdg
 	dev-python/pyaml

--- a/games-util/ProtonUp-Qt/ProtonUp-Qt-9999.ebuild
+++ b/games-util/ProtonUp-Qt/ProtonUp-Qt-9999.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 
 DEPEND="dev-python/steam
 	dev-python/requests
-	dev-python/pyside6[designer(+)]
+	dev-python/pyside6[dbus,gui,uitools,widgets]
 	dev-python/vdf
 	dev-python/pyxdg
 	dev-python/pyaml


### PR DESCRIPTION
Problem was noticed after the recent pyside6 update (6.8.1 became stable).