### PR TITLE
gui-apps/sfwbar: Add USE flags

### DIFF
--- a/gui-apps/sfwbar/metadata.xml
+++ b/gui-apps/sfwbar/metadata.xml
@@ -6,7 +6,16 @@
 		<name>Lev Babiev</name>
 	</maintainer>
 	<use>
-		<flag name="mpd">Add support for Music Player Daemon</flag>
+		<flag name="mpd">Enable support for Music Player Daemon</flag>
+		<flag name="menu">Enable support for application menu generator. Default enabled by upstream</flag>
+		<flag name="network">Enable support for network related features</flag>
+		<flag name="networkmanager">Enable support for the networkmanager wifi module</flag>
+		<flag name="iwd">Enable support for the iwd wifi module</flag>
+		<flag name="notification">Enable support for notification center and idle notifications</flag>
+		<flag name="bluetooth">Enable support for bluetooth with the bluez module</flag>
+		<flag name="idleinhibit">Enable support for Idle inhibit protocol. Prevents screenlockers (e.g swaylock) from popping up by inhibiting idle mode</flag>
+		<flag name="bsdctl">Enable support for BSD sysctl module. Default disabled by upstream</flag>
+		<flag name="man">Rebuild man pages from rst files</flag>
 	</use>
 	<upstream>
 		<remote-id type="github">LBCrion/sfwbar</remote-id>

--- a/gui-apps/sfwbar/sfwbar-1.0_beta15.ebuild
+++ b/gui-apps/sfwbar/sfwbar-1.0_beta15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg-utils
 
 DESCRIPTION="S* Floating Window Bar"
 HOMEPAGE="https://github.com/LBCrion/sfwbar"
@@ -53,4 +53,12 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/gui-apps/sfwbar/sfwbar-1.0_beta15.ebuild
+++ b/gui-apps/sfwbar/sfwbar-1.0_beta15.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson xdg
+inherit meson
 
 DESCRIPTION="S* Floating Window Bar"
 HOMEPAGE="https://github.com/LBCrion/sfwbar"
@@ -13,7 +13,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
 
-IUSE="X mpd pulseaudio alsa"
+IUSE="X mpd pulseaudio alsa network networkmanager iwd bluetooth man idleinhibit bsdctl"
 
 COMMON_DEPEND="
 	dev-libs/glib:2
@@ -43,12 +43,13 @@ src_configure() {
 		$(meson_feature mpd)
 		$(meson_feature pulseaudio pulse)
 		$(meson_feature X xkb)
-		-Dnetwork=enabled
-		-Didleinhibit=enabled
-		-Dbluez=enabled
-		-Dbsdctl=disabled
-		-Diwd=enabled
-		-Dnm=enabled
+		$(meson_feature network)
+		$(meson_feature networkmanager nm)
+		$(meson_feature iwd)
+		$(meson_feature bluetooth bluez)
+		$(meson_feature bsdctl)
+		$(meson_feature man build-docs)
+		$(meson_feature idleinhibit)
 	)
 
 	meson_src_configure

--- a/gui-apps/sfwbar/sfwbar-1.0_beta16.ebuild
+++ b/gui-apps/sfwbar/sfwbar-1.0_beta16.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson xdg
+inherit meson
 
 DESCRIPTION="S* Floating Window Bar"
 HOMEPAGE="https://github.com/LBCrion/sfwbar"
@@ -13,7 +13,7 @@ LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64"
 
-IUSE="X mpd pulseaudio alsa"
+IUSE="+menu X mpd pulseaudio alsa network networkmanager iwd bluetooth notification man idleinhibit bsdctl"
 
 COMMON_DEPEND="
 	dev-libs/glib:2
@@ -43,14 +43,16 @@ src_configure() {
 		$(meson_feature mpd)
 		$(meson_feature pulseaudio pulse)
 		$(meson_feature X xkb)
-		-Dnetwork=enabled
-		-Didleinhibit=enabled
-		-Dbluez=enabled
-		-Dbsdctl=disabled
-		-Diwd=enabled
-		-Dnm=enabled
-		-Dappmenu=enabled
-		-Dncenter=enabled
+		$(meson_feature network)
+		$(meson_feature networkmanager nm)
+		$(meson_feature iwd)
+		$(meson_feature menu appmenu)
+		$(meson_feature bluetooth bluez)
+		$(meson_feature bsdctl)
+		$(meson_feature notification ncenter)
+		$(meson_feature notification idle)
+		$(meson_feature man build-docs)
+		$(meson_feature idleinhibit)
 	)
 
 	meson_src_configure

--- a/gui-apps/sfwbar/sfwbar-1.0_beta16.ebuild
+++ b/gui-apps/sfwbar/sfwbar-1.0_beta16.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-inherit meson
+inherit meson xdg-utils
 
 DESCRIPTION="S* Floating Window Bar"
 HOMEPAGE="https://github.com/LBCrion/sfwbar"
@@ -56,4 +56,12 @@ src_configure() {
 	)
 
 	meson_src_configure
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }


### PR DESCRIPTION
Added USE flags to make all of the modules optional since they were enabled by default. E.g not everyone needs bluetooth support, or simultaneous iwd AND networkmanager support. 

No errors with pkgcheck and it is compiling without errors. Added respective USE flag descriptions as well.

Removed xdg from inherit because it wasn't used anymore.

Pull request because I'm not sure if maintainer @LBCrion agrees. Tried to reach per E-Mail but no luck.