### PR TITLE
dev-zig/zls: switch to slotted zig

### DIFF
--- a/app-eselect/eselect-zls/eselect-zls-1.ebuild
+++ b/app-eselect/eselect-zls/eselect-zls-1.ebuild
@@ -1,0 +1,20 @@
+# Copyright 2023-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="Manages Zig Language Server versions"
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+
+RDEPEND="app-admin/eselect"
+
+S="${WORKDIR}"
+
+src_install() {
+	insinto /usr/share/eselect/modules/
+	newins "${FILESDIR}"/zls.eselect-${PVR} zls.eselect
+}

--- a/app-eselect/eselect-zls/files/zls.eselect-1
+++ b/app-eselect/eselect-zls/files/zls.eselect-1
@@ -1,0 +1,132 @@
+# -*-eselect-*-  vim: ft=eselect
+# Copyright 2022-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+DESCRIPTION="Manage Zig Language Server versions"
+MAINTAINER="demize@unstable.systems"
+
+show_selected_target() {
+	readlink "${EROOT}/usr/bin/zls"
+}
+
+find_targets() {
+	for f in "${EROOT}"/usr/bin/zls-*; do
+		[[ -f "${f}" ]] && basename "${f}"
+	done
+}
+
+remove_symlinks() {
+	rm "${EROOT}/usr/bin/zls"
+}
+
+set_symlinks() {
+	local target=$1
+	if is_number "${target}"; then
+		local targets=( $(find_targets) )
+		target=${targets[target-1]}
+	fi
+
+	[[ -z "${target}" || ! -f "${EROOT}/usr/bin/${target}" ]] \
+	&& die -q "Target \"$1\" doesn't appear to be valid!"
+
+	ln -s "${target}" "${EROOT}/usr/bin/zls"
+}
+
+
+
+### show action ###
+
+describe_show() {
+	echo "Show current Zig Language Server version"
+}
+
+do_show() {
+	write_list_start "Current Zig Language Server version:"
+	if [[ -L "${EROOT}/usr/bin/zls" ]]; then
+		write_kv_list_entry "$(show_selected_target)" ""
+	else
+		write_kv_list_entry "(unset)" ""
+	fi
+}
+
+### list action ###
+
+describe_list() {
+	echo "List available Zig Language Server versions"
+}
+
+do_list() {
+	local targets=( $(find_targets) )
+	local selected_target
+	selected_target=$(show_selected_target)
+
+	write_list_start "Available Zig Language Server versions:"
+	for (( i = 0; i < ${#targets[@]}; i++ )); do
+		[[ ${targets[i]} == "${selected_target}" ]] && targets[i]=$(highlight_marker "${targets[i]}")
+	done
+	write_numbered_list -m "(none found)" "${targets[@]}"
+}
+
+
+### set action ###
+
+describe_set() {
+	echo "Set active Zig Language Server version"
+}
+
+describe_set_parameters() {
+	echo "<target>"
+}
+
+describe_set_options() {
+	echo "target:      Target name or number (from 'list' action)"
+}
+
+do_set() {
+	[[ -z $1 ]] && die -q "You need to specify a target"
+	[[ $# -gt 1 ]] && die -q "Too many parameters"
+	test_usr_bin_writeable
+
+	if [[ -L "${EROOT}/usr/bin/zls" ]]; then
+		remove_symlinks || die -q "Couldn't remove symlink"
+	fi
+	set_symlinks "$1" || die -q "Couldn't set a new symlink"
+}
+
+
+### update action ###
+
+describe_update() {
+    echo "Automatically update the Zig Language Server symlink"
+}
+
+describe_update_options() {
+    echo "ifunset: Do not override currently set version"
+}
+
+do_update() {
+    [[ -z $1 || $1 == ifunset ]] || die -q "Usage error"
+    [[ $# -gt 1 ]] && die -q "Too many parameters"
+	test_usr_bin_writeable
+
+    if [[ -L ${EROOT}/usr/bin/zls ]]; then
+        if [[ $1 == ifunset && -e ${EROOT}/usr/bin/zls ]]; then
+            return
+        fi
+        remove_symlinks
+    elif [[ -e ${EROOT}/usr/bin/zls ]]; then
+        die -q "${EROOT}/usr/bin/zls exists but is not a symlink"
+    fi
+
+    local targets=( $(find_targets) )
+    if [[ ${#targets[@]} -gt 0 ]]; then
+        set_symlinks "${targets[${#targets[@]}-1]}"
+    fi
+}
+
+
+### helper functions ###
+
+test_usr_bin_writeable() {
+    [[ -w ${EROOT}/usr/bin ]] || die -q "${EROOT}/usr/bin not writeable by current user. Are you root?"
+}

--- a/app-eselect/eselect-zls/metadata.xml
+++ b/app-eselect/eselect-zls/metadata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<name>demize</name>
+		<email>demize@unstable.systems</email>
+	</maintainer>
+	<stabilize-allarches/>
+</pkgmetadata>

--- a/dev-zig/zls/zls-0.13.0-r2.ebuild
+++ b/dev-zig/zls/zls-0.13.0-r2.ebuild
@@ -31,13 +31,13 @@ inherit zig
 SRC_URI+="${ZBS_DEPENDENCIES_SRC_URI}"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="${ZIG_SLOT}"
 
 # Sync with "minimum_runtime_zig_version" from upstream's "build.zig".
 RDEPEND="
 	|| (
-		>=dev-lang/zig-0.12.0
-		>=dev-lang/zig-bin-0.12.0
+		dev-lang/zig:${ZIG_SLOT}=
+		dev-lang/zig-bin:${ZIG_SLOT}=
 	)
 "
 
@@ -60,6 +60,12 @@ src_configure() {
 	)
 
 	zig_src_configure
+}
+
+src_install() {
+    local zls_install_dest="${EPREFIX}/usr/$(get_libdir)/zls/${PV}"
+    zig_src_install --prefix ${zls_install_dest}
+    dosym -r "${zls_install_dest}/bin/zls" "/usr/bin/zls-${PV}"
 }
 
 pkg_postinst() {

--- a/dev-zig/zls/zls-0.13.0-r2.ebuild
+++ b/dev-zig/zls/zls-0.13.0-r2.ebuild
@@ -69,6 +69,7 @@ src_install() {
 }
 
 pkg_postinst() {
+    eselect zls update ifunset || die
 	elog "You can find configuration guide here:"
 	elog "https://zigtools.org/zls/"
 }

--- a/dev-zig/zls/zls-9999.ebuild
+++ b/dev-zig/zls/zls-9999.ebuild
@@ -68,6 +68,7 @@ src_install() {
 }
 
 pkg_postinst() {
+    eselect zls update ifunset || die
 	elog "You can find configuration guide here:"
 	elog "https://zigtools.org/zls/"
 }

--- a/dev-zig/zls/zls-9999.ebuild
+++ b/dev-zig/zls/zls-9999.ebuild
@@ -31,13 +31,13 @@ inherit zig
 SRC_URI+="${ZBS_DEPENDENCIES_SRC_URI}"
 
 LICENSE="MIT"
-SLOT="0"
+SLOT="${ZIG_SLOT}"
 
 # Sync with "minimum_runtime_zig_version" from upstream's "build.zig".
 RDEPEND="
 	|| (
-		>=dev-lang/zig-9999
-		>=dev-lang/zig-bin-9999
+		dev-lang/zig:${ZIG_SLOT}=
+		dev-lang/zig-bin:${ZIG_SLOT}=
 	)
 "
 
@@ -59,6 +59,12 @@ src_configure() {
 	)
 
 	zig_src_configure
+}
+
+src_install() {
+    local zls_install_dest="${EPREFIX}/usr/$(get_libdir)/zls/${PV}"
+    zig_src_install --prefix ${zls_install_dest}
+    dosym -r "${zls_install_dest}/bin/zls" "/usr/bin/zls-${PV}"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Opening a PR for this because I'm not convinced it's actually a good idea, but a discussion with @BratishkaErik is probably worth having. Marking it as a draft since it's more for feedback anyway, and I'm sure there's changes to be made if this is something that makes sense.

Trying to get myself started with zig (and specifically trying to get a couple variations of a project off the ground) I'm finding myself switching between zig master and zig 0.13. But I also noticed that ZLS pretty clearly warns in its [install instructions](https://zigtools.org/zls/) that you should match your version of ZLS with the version of zig you're using.

So I threw this together, as what feels like a somewhat idiomatic approach (given zig is in ::gentoo and ZLS is in ::guru). It's based heavily on the approach in the zig ebuild itself, and while I'm not really a fan of a separate `eselect zls` here, since I'd rather see it integrated into `eselect zig`, this does seem to work.

But like I said, I'm not convinced it's a good idea, so I'd appreciate any feedback (or criticism!) from Eric or anyone else. In any case, it's a major change, and not one I'd make on my own (on my package, and *especially* not on anyone else's).

Feel free to ping me on IRC to discuss; I'm demize95 on there :)