### PR TITLE
Allow ollama-0.5.7 to use NVIDIA cards

### DIFF
--- a/acct-user/ollama/ollama-1-r1.ebuild
+++ b/acct-user/ollama/ollama-1-r1.ebuild
@@ -9,6 +9,6 @@ DESCRIPTION="A user for ollama"
 ACCT_USER_ID=-1
 ACCT_USER_HOME=/var/lib/ollama
 ACCT_USER_HOME_PERMS=0700
-ACCT_USER_GROUPS=( ollama )
+ACCT_USER_GROUPS=( ollama video )
 
 acct-user_add_deps

--- a/app-misc/ollama/ollama-0.5.7-r2.ebuild
+++ b/app-misc/ollama/ollama-0.5.7-r2.ebuild
@@ -167,6 +167,15 @@ src_install() {
 		fperms +x /usr/lib/ollama/runners/rocm/ollama_llama_server
 	fi
 
+	if use cuda; then
+		if has_version "=dev-util/nvidia-cuda-toolkit-11*"; then
+			fperms +x /usr/lib/ollama/runners/cuda_v11/ollama_llama_server
+		fi
+		if has_version "=dev-util/nvidia-cuda-toolkit-12*"; then
+			fperms +x /usr/lib/ollama/runners/cuda_v12/ollama_llama_server
+		fi
+	fi
+
 	doinitd "${FILESDIR}"/ollama.init
 	systemd_dounit "${FILESDIR}"/ollama.service
 }


### PR DESCRIPTION
This includes 2 fixes:

- Add user `ollama` to group `video`.
- Make /usr/lib/ollama/runners/cuda_v{11,12}/ollama_llama_server executable