### PR TITLE
media-gfx/VulkanFX: new package, add 9999

### DIFF
--- a/media-gfx/VulkanFX/VulkanFX-9999.ebuild
+++ b/media-gfx/VulkanFX/VulkanFX-9999.ebuild
@@ -1,0 +1,50 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+MULTILIB_COMPAT=( abi_x86_{32,64} )
+
+inherit meson-multilib
+
+DESCRIPTION="A vulkan post processing layer"
+HOMEPAGE="https://github.com/pchome/VulkanFX"
+
+if [[ ${PV} == "9999" ]] ; then
+	EGIT_REPO_URI="https://github.com/pchome/VulkanFX.git"
+	EGIT_SUBMODULES=()
+	inherit git-r3
+	SRC_URI=""
+else
+	SRC_URI="https://github.com/pchome/VulkanFX/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+	KEYWORDS="-* ~amd64"
+	S="${WORKDIR}/VulkanFX-${PV}"
+fi
+
+LICENSE="ZLIB"
+SLOT="0"
+
+RESTRICT="test"
+
+RDEPEND="!<media-libs/vulkan-loader-1.1:=[${MULTILIB_USEDEP},layers]
+	!media-gfx/vkBasalt
+	>=dev-util/reshade-fx-5.9.2"
+
+BDEPEND="!<dev-util/vulkan-headers-1.1
+	dev-util/glslang
+	dev-libs/stb
+	>=dev-build/meson-0.50"
+
+DEPEND="${RDEPEND}"
+
+multilib_src_configure() {
+	local emesonargs=(
+		--unity=on
+		-Dunity_size=100
+	)
+	meson_src_configure
+}
+
+multilib_src_install() {
+	meson_src_install
+}

--- a/media-gfx/VulkanFX/metadata.xml
+++ b/media-gfx/VulkanFX/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<upstream>
+		<remote-id type="github">pchome/VulkanFX</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
A fork of vkBasalt with the following noticeable changes:
* unbundled `stb`
* unbundled ReShadeFX

Uses `dev-util/reshade-fx` shared library from #306 

I did a quick test:
`$ git clone https://github.com/crosire/reshade-shaders /tmp/fxs`
`$ ENABLE_VKBASALT=1 VKBASALT_CONFIG='effects=fxaa:cas:dlt;casSharpness=1.0;dlt=/tmp/fxs/Shaders/Daltonize.fx;reshadeTexturePath=/tmp/fxs/Textures;reshadeIncludePath=/tmp/fxs/Shaders' vkgears`

![VulkanFX-vkgears](https://github.com/user-attachments/assets/8db2e3af-7916-4acf-94f6-a3f181ddd1fc)
