### PR TITLE
net-wireless/sdrpp: allow rtl-sdr-blog to satisfy dependency

### DIFF
--- a/net-wireless/sdrpp/sdrpp-1.2.0_pre20240607.ebuild
+++ b/net-wireless/sdrpp/sdrpp-1.2.0_pre20240607.ebuild
@@ -50,7 +50,10 @@ DEPEND="sci-libs/fftw
 		net-wireless/soapysdr
 	)
 	rtlsdr? (
-		net-wireless/rtl-sdr
+		|| (
+			net-wireless/rtl-sdr
+			net-wireless/rtl-sdr-blog
+		)
 	)
 	uhd? (
 		net-wireless/uhd


### PR DESCRIPTION
net-wireless/rtl-sdr-blog is a drop in replacement fork of net-wireless/rtl-sdr recently added to the gentoo tree. This change allows either one to be used with sdr++
@redawl 