### PR TITLE
app-shells/direnv: Add EPREFIX to emake command

### DIFF
--- a/app-shells/direnv/direnv-2.36.0.ebuild
+++ b/app-shells/direnv/direnv-2.36.0.ebuild
@@ -25,5 +25,5 @@ DOCS=( {CHANGELOG,README}.md )
 
 src_install() {
 	einstalldocs
-	emake DESTDIR="${D}" PREFIX="/usr" install
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
 }

--- a/app-shells/direnv/direnv-9999.ebuild
+++ b/app-shells/direnv/direnv-9999.ebuild
@@ -21,5 +21,5 @@ DOCS=( {CHANGELOG,README}.md )
 
 src_install() {
 	einstalldocs
-	emake DESTDIR="${D}" PREFIX="/usr" install
+	emake DESTDIR="${D}" PREFIX="${EPREFIX}/usr" install
 }


### PR DESCRIPTION
This allows to install direnv with a custom prefix