### PR TITLE
gui-apps/hyprlock: fix gui-libs/hyprutils version requirement

### DIFF
--- a/gui-apps/hyprlock/hyprlock-0.8.2-r1.ebuild
+++ b/gui-apps/hyprlock/hyprlock-0.8.2-r1.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-libs/hyprlang-0.6.0
 	dev-libs/wayland
 	>=dev-util/hyprwayland-scanner-0.4.4
-	>=gui-libs/hyprutils-0.2.6:=
+	>=gui-libs/hyprutils-0.5.0:=
 	media-libs/libglvnd
 	media-libs/libjpeg-turbo:=
 	media-libs/libwebp:=

--- a/gui-apps/hyprlock/hyprlock-9999.ebuild
+++ b/gui-apps/hyprlock/hyprlock-9999.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	>=dev-libs/hyprlang-0.6.0
 	dev-libs/wayland
 	>=dev-util/hyprwayland-scanner-0.4.4
-	>=gui-libs/hyprutils-0.2.6:=
+	>=gui-libs/hyprutils-0.5.0:=
 	media-libs/libglvnd
 	media-libs/libjpeg-turbo:=
 	media-libs/libwebp:=


### PR DESCRIPTION
See-also: https://github.com/hyprwm/hyprlock/commit/2a6ec58366f987e6dc425b227ff7aaa7260b821a