### PR TITLE
dev-cpp/wt: revert adding qtbase dep

### DIFF
--- a/dev-cpp/wt/wt-4.11.4-r2.ebuild
+++ b/dev-cpp/wt/wt-4.11.4-r2.ebuild
@@ -15,12 +15,10 @@ KEYWORDS="~amd64"
 IUSE="doc mysql opengl +pango pdf postgres ssl"
 
 DEPEND="
-	dev-qt/qtbase:6
 	<=dev-libs/boost-1.86.0:=
 	media-libs/libharu
 	media-gfx/graphicsmagick[jpeg,png]
 	sys-libs/zlib
-
 	mysql? ( virtual/mysql )
 	opengl? ( virtual/opengl )
 	pango? ( x11-libs/pango )
@@ -51,9 +49,10 @@ src_configure() {
 		-DENABLE_POSTGRES=$(usex postgres)
 		-DENABLE_MYSQL=$(usex mysql)
 		-DENABLE_FIREBIRD=OFF
+		# QT is only required for examples
 		-DENABLE_QT4=OFF
 		-DENABLE_QT5=OFF
-		-DENABLE_QT6=ON
+		-DENABLE_QT6=OFF
 		-DENABLE_SAML=ON
 		-DENABLE_OPENGL=$(usex opengl)
 	)


### PR DESCRIPTION
revert 8a6c242
wt needs qt only for building [examples](https://github.com/search?q=repo%3Aemweb%2Fwt+%2F(%3F-i)include+<Q%2F) that are already disabled

@stkw0 @antecrescent 