### PR TITLE
TODO.md: remove croissant

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@ If you find an interesting piece of software here, consider to package it, also 
    Name      |  Buildsystem  |    Category   |     User      |    Need help  | Dependency
 ------------ | ------------- | ------------- | ------------- | ------------- | -------------
 [ActivityWatch](https://github.com/ActivityWatch/activitywatch) | setuptools | utils | David Roman | ✔ | ✖
-[croissant](https://github.com/giann/croissant) | ? | dev-lua | NRK | ✔ | ?
 [greenclip](https://github.com/erebe/greenclip) (source build) | cabal | x11-misc | NRK | ✔ | ✖
 [texlab](https://github.com/latex-lsp/texlab) | cargo | app-text | Joshua | ✔ | ?
 [pass-import](https://github.com/roddhjav/pass-import) | setuptools | app-admin | Joshua | ✔ | ✔


### PR DESCRIPTION
dev-lua/croissant is now present, so remove it from the todo list.