### PR TITLE
media-gfx/swayimg: metadata: update USE=drm description

### DIFF
--- a/media-gfx/swayimg/metadata.xml
+++ b/media-gfx/swayimg/metadata.xml
@@ -8,7 +8,7 @@
 		<remote-id type="github">artemsen/swayimg</remote-id>
 	</upstream>
 	<use>
-		<flag name="drm">Enable DRM renderig support (DRM UI)</flag>
+		<flag name="drm">Enable support for Direct Rendering Manager</flag>
 		<flag name="exr">Enable support for EXR image format</flag>
 		<flag name="jpegxl">Enable support for JPEG XL image format</flag>
 		<flag name="sixel">Enable support for Sixel image format</flag>


### PR DESCRIPTION
I have improved the description upstream https://github.com/artemsen/swayimg/pull/328#event-18597325725 and since we have it copied I thought I'd do it here also.

This is a PR because I do not know if removing (DRM UI) is a 100% positive change.