### PR TITLE
Why are there links to non official ollama repo's?

### DIFF
--- a/sci-ml/ollama/ollama-0.9.3.ebuild
+++ b/sci-ml/ollama/ollama-0.9.3.ebuild
@@ -18,7 +18,6 @@ if [[ ${PV} == *9999* ]]; then
 else
 	SRC_URI="
 		https://github.com/ollama/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/negril/gentoo-overlay-vendored/raw/refs/heads/blobs/${P}-vendor.tar.xz
 	"
 	KEYWORDS="~amd64"
 fi

--- a/sci-ml/ollama/ollama-0.9.5.ebuild
+++ b/sci-ml/ollama/ollama-0.9.5.ebuild
@@ -18,7 +18,6 @@ if [[ ${PV} == *9999* ]]; then
 else
 	SRC_URI="
 		https://github.com/ollama/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/negril/gentoo-overlay-vendored/raw/refs/heads/blobs/${P}-vendor.tar.xz
 	"
 	KEYWORDS="~amd64"
 fi

--- a/sci-ml/ollama/ollama-0.9.6.ebuild
+++ b/sci-ml/ollama/ollama-0.9.6.ebuild
@@ -18,7 +18,6 @@ if [[ ${PV} == *9999* ]]; then
 else
 	SRC_URI="
 		https://github.com/ollama/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/negril/gentoo-overlay-vendored/raw/refs/heads/blobs/${P}-vendor.tar.xz
 	"
 	KEYWORDS="~amd64"
 fi

--- a/sci-ml/ollama/ollama-9999.ebuild
+++ b/sci-ml/ollama/ollama-9999.ebuild
@@ -18,7 +18,6 @@ if [[ ${PV} == *9999* ]]; then
 else
 	SRC_URI="
 		https://github.com/ollama/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.gh.tar.gz
-		https://github.com/negril/gentoo-overlay-vendored/raw/refs/heads/blobs/${P}-vendor.tar.xz
 	"
 	KEYWORDS="~amd64"
 fi


### PR DESCRIPTION
removed SRC_URI's that pointed to [negril's ](https://github.com/negril/gentoo-overlay-vendored/) personal repository. It just looks real suspicious and does not need to be there.