### PR TITLE
app-office/openoffice-bin: fix long line

### DIFF
--- a/app-office/openoffice-bin/openoffice-bin-4.1.15.ebuild
+++ b/app-office/openoffice-bin/openoffice-bin-4.1.15.ebuild
@@ -90,7 +90,9 @@ src_unpack() {
 	eprefixify "${T}"/{50-${PN},wrapper.in}
 
 	# 'pyuno' is excluded from unpack list to switch off Python2 scripts support
-	for i in base calc core01 core02 core03 core04 core05 core06 core07 draw graphicfilter images impress math ogltrans ooofonts ooolinguistic ure writer xsltfilter ; do
+	for i in base calc core01 core02 core03 core04 core05 core06 core07 draw graphicfilter images impress math ogltrans\
+		ooofonts ooolinguistic ure writer xsltfilter
+	do
 		rpm_unpack "./${UP}/${NM}-${i}-${BVER}.${XARCH}.rpm"
 	done
 


### PR DESCRIPTION
fixes the following pkgcheck warnings:

app-office/openoffice-bin
  ExcessiveLineLength: version 4.1.15: excessive line length (over 120 characters) on line: 93

@band-a-prend pinging you since you're the maintainer