### PR TITLE
gui-libs/gtk4-layer-shell: add support for ~x86

### DIFF
--- a/gui-libs/gtk4-layer-shell/gtk4-layer-shell-1.1.1-r1.ebuild
+++ b/gui-libs/gtk4-layer-shell/gtk4-layer-shell-1.1.1-r1.ebuild
@@ -9,7 +9,7 @@ SRC_URI="https://github.com/wmww/${PN}/archive/refs/tags/v${PV}.tar.gz -> ${P}.t
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64"
+KEYWORDS="~amd64 ~x86"
 
 IUSE="examples doc test smoke-tests introspection vala"
 REQUIRED_USE="vala? ( introspection )"


### PR DESCRIPTION
gtk4-layer-shell is a dependency of gui-apps/swaync-0.12, which supports `~x86`. Therefore, add the support to this dependency.

@pHlt7, as you noted this in [your comment](https://github.com/gentoo/guru/commit/7d81327474ea1afe1d9353112a1c152cecb38d9c#r162677442), I guess that you have a x86 installation to test this. I cannot test it myself, can you confirm to me that it works?

Thanks