### PR TITLE
app-misc/lf: EAPI 7 -> 8; insinto -> shell-completion.eclass; go build -> ego ebuild

### DIFF
--- a/app-misc/lf/lf-27.ebuild
+++ b/app-misc/lf/lf-27.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit go-module bash-completion-r1 desktop xdg
+inherit go-module shell-completion desktop xdg
 
 DESCRIPTION="Terminal file manager"
 HOMEPAGE="https://github.com/gokcehan/lf"
@@ -25,7 +25,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {
@@ -45,14 +45,11 @@ src_install() {
 	newbashcomp "etc/${PN}.bash" "${PN}"
 
 	# zsh-completion
-	insinto /usr/share/zsh/site-functions
-	newins "etc/${PN}.zsh" "_${PN}"
+	newzshcomp "etc/${PN}.zsh" "_${PN}"
 
 	# fish-completion
-	insinto /usr/share/fish/vendor_completions.d
-	doins "etc/${PN}.fish"
-	insinto /usr/share/fish/vendor_functions.d
-	doins "etc/${PN}cd.fish"
+	dofishcomp "etc/${PN}.fish"
+	dofishcomp "etc/${PN}cd.fish"
 
 	domenu "${PN}.desktop"
 }

--- a/app-misc/lf/lf-28-r1.ebuild
+++ b/app-misc/lf/lf-28-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,7 +25,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {

--- a/app-misc/lf/lf-29.ebuild
+++ b/app-misc/lf/lf-29.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit go-module bash-completion-r1 desktop xdg
+inherit go-module shell-completion desktop xdg
 
 DESCRIPTION="Terminal file manager"
 HOMEPAGE="https://github.com/gokcehan/lf"
@@ -25,7 +25,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {
@@ -45,14 +45,11 @@ src_install() {
 	newbashcomp "etc/${PN}.bash" "${PN}"
 
 	# zsh-completion
-	insinto /usr/share/zsh/site-functions
-	newins "etc/${PN}.zsh" "_${PN}"
+	newzshcomp "etc/${PN}.zsh" "_${PN}"
 
 	# fish-completion
-	insinto /usr/share/fish/vendor_completions.d
-	doins "etc/${PN}.fish"
-	insinto /usr/share/fish/vendor_functions.d
-	doins "etc/${PN}cd.fish"
+	dofishcomp "etc/${PN}.fish"
+	dofishcomp "etc/${PN}cd.fish"
 
 	domenu "${PN}.desktop"
 }

--- a/app-misc/lf/lf-30.ebuild
+++ b/app-misc/lf/lf-30.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit go-module bash-completion-r1 desktop xdg
+inherit go-module shell-completion desktop xdg
 
 DESCRIPTION="Terminal file manager"
 HOMEPAGE="https://github.com/gokcehan/lf"
@@ -25,7 +25,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {
@@ -45,14 +45,11 @@ src_install() {
 	newbashcomp "etc/${PN}.bash" "${PN}"
 
 	# zsh-completion
-	insinto /usr/share/zsh/site-functions
-	newins "etc/${PN}.zsh" "_${PN}"
+	newzshcomp "etc/${PN}.zsh" "_${PN}"
 
 	# fish-completion
-	insinto /usr/share/fish/vendor_completions.d
-	doins "etc/${PN}.fish"
-	insinto /usr/share/fish/vendor_functions.d
-	doins "etc/${PN}cd.fish"
+	dofishcomp "etc/${PN}.fish"
+	dofishcomp "etc/${PN}cd.fish"
 
 	domenu "${PN}.desktop"
 }

--- a/app-misc/lf/lf-31.ebuild
+++ b/app-misc/lf/lf-31.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -25,7 +25,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {

--- a/app-misc/lf/lf-32.ebuild
+++ b/app-misc/lf/lf-32.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -23,7 +23,7 @@ src_compile() {
 		ldflags+=' -extldflags "-static"'
 	}
 
-	go build -ldflags="${ldflags}" || die 'go build failed'
+	ego build -ldflags="${ldflags}"
 }
 
 src_install() {

--- a/app-misc/lf/lf-33.ebuild
+++ b/app-misc/lf/lf-33.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8


### PR DESCRIPTION
also fixes the following pkgcheck warnings:

app-misc/lf
  DeprecatedInsinto: version 27: deprecated insinto usage (use dozshcomp or newzshcomp from shell-completion.eclass instead), line 48: insinto /usr/share/zsh/site-functions
  DeprecatedInsinto: version 27: deprecated insinto usage (use dofishcomp or newfishcomp from shell-completion.eclass instead), line 52: insinto /usr/share/fish/vendor_completions.d
  DeprecatedInsinto: version 29: deprecated insinto usage (use dozshcomp or newzshcomp from shell-completion.eclass instead), line 48: insinto /usr/share/zsh/site-functions
  DeprecatedInsinto: version 29: deprecated insinto usage (use dofishcomp or newfishcomp from shell-completion.eclass instead), line 52: insinto /usr/share/fish/vendor_completions.d
  DeprecatedInsinto: version 30: deprecated insinto usage (use dozshcomp or newzshcomp from shell-completion.eclass instead), line 48: insinto /usr/share/zsh/site-functions
  DeprecatedInsinto: version 30: deprecated insinto usage (use dofishcomp or newfishcomp from shell-completion.eclass instead), line 52: insinto /usr/share/fish/vendor_completions.d

@ephemer4l pinging you since you're the maintainer