### PR TITLE
profiles/package.mask: mask unmaintained deps for removal

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -22,9 +22,12 @@
 # This package is unmaintained, has an ambiguous license and upstream is
 # unresponsive. Its sole revdep is app-forensics/mvt, which has been outdated
 # for two years and depends on masked dev-python/tld.
+# Mask unmaintained dependencies of these two packages as well.
 # Removal on 2025-08-28, bug #952156
 dev-python/iOSbackup
 app-forensics/mvt
+dev-python/biplist
+dev-python/NSKeyedUnArchiver
 
 # Anna (cybertailor) Vyalkova <cyber+gentoo@sysrq.in> (2025-07-27)
 # Vulnerable to a cross-site scripting attack.


### PR DESCRIPTION
* dev-python/biplist The only (incorrect) consumer is the last-rited app-forensics/mvt package. Has no test suite wired up and only patched support for dev-lang/python:3.9 or later since the last upstream commit happened in 2018.
@stkw0 You are listed as the maintainer, is this okay with you?

* dev-python/NSKeyedUnArchiver The only consumer is the last-rited dev-python/iOSbackup package. It has no support for dev-lang/python:3.13, LICENSE is incorrect and upstream provides no tests.