### PR TITLE
FOR REVIEW: games-strategy/7k-ambition: require gcc-12 for multiplayer

### DIFF
--- a/games-strategy/7k-ambition/7k-ambition-3.2.4.ebuild
+++ b/games-strategy/7k-ambition/7k-ambition-3.2.4.ebuild
@@ -26,6 +26,7 @@ SLOT="0"
 IUSE="+nls +multiplayer +music"
 RESTRICT="music? ( bindist ) mirror"
 
+BDEPEND="multiplayer? ( sys-devel/gcc:12 )"
 DEPEND="
 	dev-libs/boost:=
 	nls? ( <=sys-devel/gettext-0.22.5-r2 )
@@ -47,6 +48,15 @@ src_unpack() {
 }
 
 src_prepare() {
+	if use multiplayer ; then
+		if tc-is-gcc && ver_test $(gcc-version) -ne 12 ; then
+			eerror "Seven Kingdoms multiplayer is known to work only with" \
+			" gcc-12.  Please"
+			eerror " use gcc-12 to build Seven Kingdoms."
+			die
+		fi
+	fi
+
 	default
 	eautoreconf
 }

--- a/games-strategy/7k-ambition/7k-ambition-9999.ebuild
+++ b/games-strategy/7k-ambition/7k-ambition-9999.ebuild
@@ -26,6 +26,7 @@ SLOT="0"
 IUSE="+nls +multiplayer +music"
 RESTRICT="music? ( bindist ) mirror"
 
+BDEPEND="multiplayer? ( sys-devel/gcc:12 )"
 DEPEND="
 	dev-libs/boost:=
 	nls? ( <=sys-devel/gettext-0.22.5-r2 )
@@ -47,6 +48,15 @@ src_unpack() {
 }
 
 src_prepare() {
+	if use multiplayer ; then
+		if tc-is-gcc && ver_test $(gcc-version) -ne 12 ; then
+			eerror "Seven Kingdoms multiplayer is known to work only with" \
+			" gcc-12.  Please"
+			eerror " use gcc-12 to build Seven Kingdoms."
+			die
+		fi
+	fi
+
 	default
 	eautoreconf
 }


### PR DESCRIPTION
I don't know the best way to go about this.

Due to something as yet unknown, compiling with gcc 14 causes a desync in multiplayer, so we need to build with gcc-12 (gcc-13 is unknown and untested).

So we need to check that we are building with gcc-12 and, if not, tell the user to this package to use gcc-12.