### PR TITLE
net-im/discordo: bump dev-lang/go dep to 1.25

### DIFF
--- a/net-im/discordo/discordo-9999.ebuild
+++ b/net-im/discordo/discordo-9999.ebuild
@@ -25,6 +25,7 @@ fi
 
 LICENSE="MIT"
 SLOT="0"
+BDEPEND=">=dev-lang/go-1.25"
 
 src_compile() {
 	ego build -o "bin/$PN"


### PR DESCRIPTION
At the moment of writing,

* `discordo` has `go 1.25.0` in `go.mod.`
* `dev-lang/go-1.25` is marked unstable on Gentoo amd64.

Then this package should specify the minimum Go version to not cause a compile error on stable-package-preferred systems. This commit bumps the BDEPENDS accordingly.

```bash
go: go.mod requires go >= 1.25.0 (running go 1.24.6; GOTOOLCHAIN=local)
 * ERROR: net-im/discordo-9999::guru failed (unpack phase):
 *   go mod vendor failed
```

Perhaps it would be even better practice to use ["pre" date versioning](https://leo3418.github.io/2023/02/07/avoid-9999-only-gentoo-packages.html). For example Gentoo does this with [LuaJIT](https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-lang/luajit?id=e82c891da0b880d06d8d4ff4cc42477bcbcf22a2).