### PR TITLE
Updates to dev-util/xrt ebuild

### DIFF
--- a/dev-util/xrt/xrt-202610.2.21.21.ebuild
+++ b/dev-util/xrt/xrt-202610.2.21.21.ebuild
@@ -117,6 +117,9 @@ src_prepare() {
 	sed -e "s/set (XRT_UPSTREAM 0)/set (XRT_UPSTREAM 1)/" -i src/CMake/settings.cmake || die
 
 	sed -e "s|\${XRT_INSTALL_DIR}/share/doc|\${CMAKE_INSTALL_DOCDIR}|" -i src/CMake/changelog.cmake || die
+	# Boost >= 1.89 removed the system stub library (header-only since 1.69)
+	sed -e 's/REQUIRED COMPONENTS system filesystem program_options/REQUIRED COMPONENTS filesystem program_options/g' \
+	-i src/CMake/boostUtil.cmake || die
 
 	cmake_src_prepare
 }

--- a/dev-util/xrt/xrt-202610.2.21.21.ebuild
+++ b/dev-util/xrt/xrt-202610.2.21.21.ebuild
@@ -59,6 +59,7 @@ RDEPEND="
 
 DEPEND="
 	${RDEPEND}
+	dev-cpp/ms-gsl
 	dev-libs/cxxopts
 	dev-libs/opencl-icd-loader
 	dev-libs/rapidjson

--- a/dev-util/xrt/xrt-999999.ebuild
+++ b/dev-util/xrt/xrt-999999.ebuild
@@ -61,6 +61,7 @@ RDEPEND="
 
 DEPEND="
 	${RDEPEND}
+	dev-cpp/ms-gsl
 	dev-libs/cxxopts
 	dev-libs/opencl-icd-loader
 	dev-libs/rapidjson

--- a/dev-util/xrt/xrt-999999.ebuild
+++ b/dev-util/xrt/xrt-999999.ebuild
@@ -121,7 +121,9 @@ src_prepare() {
 	sed -e "s/set (XRT_UPSTREAM 0)/set (XRT_UPSTREAM 1)/" -i src/CMake/settings.cmake || die
 
 	sed -e "s|\${XRT_INSTALL_DIR}/share/doc|\${CMAKE_INSTALL_DOCDIR}|" -i src/CMake/changelog.cmake || die
-
+	# Boost >= 1.89 removed the system stub library (header-only since 1.69)
+	sed -e 's/REQUIRED COMPONENTS system filesystem program_options/REQUIRED COMPONENTS filesystem program_options/g' \
+	-i src/CMake/boostUtil.cmake || die
 	cmake_src_prepare
 }
 


### PR DESCRIPTION
- Correcting build with boost >= 1.89.0 (otherwise fails at configure)
- Adding ms-gl into dependencies (build fails otherwise)
- see #456 as well