### PR TITLE
games-emulation/eden: add missing dependency

### DIFF
--- a/games-emulation/eden/eden-0.2.0_rc2-r1.ebuild
+++ b/games-emulation/eden/eden-0.2.0_rc2-r1.ebuild
@@ -54,6 +54,7 @@ RDEPEND="
 	qt6? (
 		dev-libs/quazip[qt6(+)]
 		dev-qt/qtbase:6[concurrent,dbus,gui,widgets]
+		dev-qt/qtcharts
 	)
 	usb? ( dev-libs/libusb )
 	web-applet? ( dev-qt/qtwebengine:6[widgets] )


### PR DESCRIPTION
Needed by the [Performance Overlay](https://git.eden-emu.dev/eden-emu/eden/src/commit/3ce5463d2df67346f0139a5d5e2223e5daa47502/src/yuzu/render/performance_overlay.cpp).