### PR TITLE
gui-apps/quickshell: fix missing USE constraint i3? ( X )

### DIFF
--- a/gui-apps/quickshell/quickshell-0.3.0.ebuild
+++ b/gui-apps/quickshell/quickshell-0.3.0.ebuild
@@ -36,10 +36,11 @@ REQUIRED_USE="
 	toplevel-management? ( wayland )
 	hyprland?            ( wayland )
 	screencopy?          ( wayland )
+	i3? ( X )
 "
 
 RDEPEND="
-	dev-qt/qtbase:6=[dbus,vulkan]
+	dev-qt/qtbase:6=[dbus,vulkan,X?]
 	dev-qt/qtsvg:6=
 	dev-qt/qtdeclarative:6=
 	x11-libs/libdrm

--- a/gui-apps/quickshell/quickshell-9999.ebuild
+++ b/gui-apps/quickshell/quickshell-9999.ebuild
@@ -33,10 +33,11 @@ REQUIRED_USE="
 	toplevel-management? ( wayland )
 	hyprland?            ( wayland )
 	screencopy?          ( wayland )
+	i3? ( X )
 "
 
 RDEPEND="
-	dev-qt/qtbase:6=[dbus,vulkan]
+	dev-qt/qtbase:6=[dbus,vulkan,X?]
 	dev-qt/qtsvg:6=
 	dev-qt/qtdeclarative:6=
 	jemalloc? ( dev-libs/jemalloc )
@@ -107,7 +108,7 @@ src_configure() {
 		-DSCREENCOPY_ICC=${_screencopy}
 		-DSCREENCOPY_WLR=${_screencopy}
 		-DSCREENCOPY_HYPRLAND_TOPLEVEL=${_screencopy}
-		-DX11=$(usex X )
+		-DX11=$(usex X)
 		-DI3=${_i3}
 		-DI3_IPC=${_i3}
 		-DSERVICE_STATUS_NOTIFIER=$(usex tray)


### PR DESCRIPTION
Quickshell.I3 qml module wasnt installed without enabling x11 dependency, the cmake file itself doesn't enforce that dependency but will silently skip i3 module without x11, see https://github.com/AvengeMedia/DankMaterialShell/issues/2437

Quickshell with X enabled also didnt compile without X enabled on qtbase.

I took the liberty to remove a space character to reduce (by 1 line) the diff between `0.3.0` and `9999`

I wasn't sure whether I should've opened the PR against master or dev.