### PR TITLE
app-admin/createrepo-rs: new package, version 0.1.8

### DIFF
--- a/app-admin/createrepo-rs/createrepo-rs-0.1.8.ebuild
+++ b/app-admin/createrepo-rs/createrepo-rs-0.1.8.ebuild
@@ -1,0 +1,38 @@
+# Copyright 2026 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit cargo
+
+DESCRIPTION="Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI"
+HOMEPAGE="https://github.com/jamesarch/createrepo_rs"
+SRC_URI="https://github.com/jamesarch/createrepo_rs/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+IUSE=""
+
+RDEPEND=""
+DEPEND="${RDEPEND}"
+
+S="${WORKDIR}/createrepo_rs-${PV}"
+
+src_unpack() {
+	cargo_live_src_unpack
+}
+
+src_compile() {
+	cargo_src_compile --release
+}
+
+src_test() {
+	cargo_src_test --release
+}
+
+src_install() {
+	dobin "target/release/createrepo_rs"
+	dodoc README.md README_zh.md
+	dodoc LICENSE
+}

--- a/app-admin/createrepo-rs/metadata.xml
+++ b/app-admin/createrepo-rs/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>jamesarch@github</email>
+		<name>jamesarch</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">jamesarch/createrepo_rs</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI, single static binary.

- GitHub: https://github.com/jamesarch/createrepo_rs
- crates.io: https://crates.io/crates/createrepo_rs
- License: GPL-2.0-or-later
- Uses cargo.eclass for build