### PR TITLE
media-gfx/beeref: update supported python versions

### DIFF
--- a/dev-python/exif/exif-1.6.0.ebuild
+++ b/dev-python/exif/exif-1.6.0.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} python3_13t )
+PYTHON_COMPAT=( python3_{12..14} python3_13t )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/dev-python/rectangle-packer/rectangle-packer-2.0.2.ebuild
+++ b/dev-python/rectangle-packer/rectangle-packer-2.0.2.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 DISTUTILS_EXT=1
 

--- a/media-gfx/beeref/beeref-0.3.3.ebuild
+++ b/media-gfx/beeref/beeref-0.3.3.ebuild
@@ -1,8 +1,8 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{12..14} )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 desktop xdg
 


### PR DESCRIPTION
Also for its dependencies:
- dev-python/exif
- dev-python/rectangle-packer