### PR TITLE
gui-apps/nwg-hello: enable py3.14, py3.15 and disable py3.12

### DIFF
--- a/gui-apps/nwg-hello/nwg-hello-0.4.2.ebuild
+++ b/gui-apps/nwg-hello/nwg-hello-0.4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{12..13} )
+PYTHON_COMPAT=( python3_{13..15} )
 DISTUTILS_USE_PEP517=setuptools
 
 inherit distutils-r1


### PR DESCRIPTION
Enabling python 3.14 and 15 - Verified on my system it compiles and works. 