### PR TITLE
Update llama-cpp-9999.ebuild The rpc server binary was renamed in upstream

### DIFF
--- a/sci-misc/llama-cpp/llama-cpp-9999.ebuild
+++ b/sci-misc/llama-cpp/llama-cpp-9999.ebuild
@@ -161,7 +161,7 @@ src_configure() {
 
 src_install() {
 	cmake_src_install
-	dobin "${BUILD_DIR}/bin/rpc-server"
+	dobin "${BUILD_DIR}/bin/ggml-rpc-server"
 
 	# avoid clashing with whisper.cpp
 	rm -rf "${ED}/usr/include"


### PR DESCRIPTION

fixes:
```
!!! dobin: /var/tmp/portage/sci-misc/llama-cpp-9999/work/llama-cpp-9999_build/bin/rpc-server does not exist

ERROR: sci-misc/llama-cpp-9999::guru failed (install phase):

dobin failed


If you need support, post the output of emerge --info '=sci-misc/llama-cpp-9999::guru',

the complete build log and the output of emerge -pqv '=sci-misc/llama-cpp-9999::guru'.

The complete build log is located at '/var/tmp/portage/sci-misc/llama-cpp-9999/temp/build.log'.

The ebuild environment file is located at '/var/tmp/portage/sci-misc/llama-cpp-9999/temp/environment'.

Working directory: '/var/tmp/portage/sci-misc/llama-cpp-9999/work/llama-cpp-9999'

S: '/var/tmp/portage/sci-misc/llama-cpp-9999/work/llama-cpp-9999'

QA Notice: file does not exist:


dobin: /var/tmp/portage/sci-misc/llama-cpp-9999/work/llama-cpp-9999_build/bin/rpc-server does not exist

>>> Failed to emerge sci-misc/llama-cpp-9999, Log file:

>>> '/var/tmp/portage/sci-misc/llama-cpp-9999/temp/build.log'
```
I have tested this change on my own devices and it fixed the error and the rpc server works again in the exact same way as before. 
I ran the rpc server like this:
```export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/llama.cpp && GGML_RPC_DEBUG=1 ggml-rpc-server```

https://github.com/ggml-org/llama.cpp/releases/tag/b9824