### PR TITLE
games-util/hid-nintendo: migrate from linux-mod to linux-mod-r1

### DIFF
--- a/games-util/hid-nintendo/hid-nintendo-9999.ebuild
+++ b/games-util/hid-nintendo/hid-nintendo-9999.ebuild
@@ -1,9 +1,9 @@
-# Copyright 2021 Gentoo Authors
+# Copyright 2021-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit git-r3 linux-mod
+inherit git-r3 linux-mod-r1
 
 DESCRIPTION="A Nintendo HID kernel module"
 HOMEPAGE="https://github.com/nicman23/dkms-hid-nintendo https://github.com/DanielOgorchock/linux"
@@ -12,11 +12,19 @@ EGIT_REPO_URI="https://github.com/nicman23/dkms-hid-nintendo"
 LICENSE="GPL-2"
 SLOT="0"
 
-MODULE_NAMES="${PN}(kernel/drivers/hid:${S}/src)"
-BUILD_TARGETS="-C /usr/src/linux M=${S}/src"
+CONFIG_CHECK="~HID ~HID_GENERIC ~USB_HID ~HIDRAW ~UHID"
 
-pkg_setup() {
-	CONFIG_CHECK="~HID ~HID_GENERIC ~USB_HID ~HIDRAW ~UHID"
-	check_extra_config
-	linux-mod_pkg_setup
+src_compile() {
+	local -a emakeargs=( "${MODULES_MAKEARGS[@]}" )
+	emake -C "${KV_OUT_DIR}" M="${S}/src" "${emakeargs[@]}" modules
+}
+
+src_install() {
+	local -a emakeargs=(
+		"${MODULES_MAKEARGS[@]}"
+		INSTALL_MOD_PATH="${ED}"
+		INSTALL_MOD_DIR=kernel/drivers/hid
+	)
+	emake -C "${KV_OUT_DIR}" M="${S}/src" "${emakeargs[@]}" modules_install
+	modules_post_process
 }


### PR DESCRIPTION
The `linux-mod.eclass` has been removed from ::gentoo, causing this ebuild to fail in the depend phase:

```
ERROR: games-util/hid-nintendo-9999::guru failed (depend phase):
  linux-mod.eclass could not be found by inherit()
```

## Changes

- Bump EAPI from 7 to 8
- Replace `inherit linux-mod` with `inherit linux-mod-r1`
- Remove `MODULE_NAMES` and `BUILD_TARGETS` (old eclass syntax)
- Remove `pkg_setup` with manual `check_extra_config` / `linux-mod_pkg_setup` (handled automatically by linux-mod-r1's exported pkg_setup)
- Move `CONFIG_CHECK` to global scope
- Add `src_compile` / `src_install` with manual `emake -C` since the upstream Makefile is a bare Kbuild fragment (`obj-m += ...`) without wrapper targets
- Use `modules_post_process` for proper strip/sign/compress handling

See linux-mod-r1 migration guide in the eclass for context.