### PR TITLE
games-emulation/rpcs3: add missing dep ( libsdl3 )

### DIFF
--- a/games-emulation/rpcs3/rpcs3-0.0.41.ebuild
+++ b/games-emulation/rpcs3/rpcs3-0.0.41.ebuild
@@ -43,7 +43,7 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="discord faudio +llvm opencv vulkan wayland"
+IUSE="discord faudio +llvm opencv vulkan X wayland"
 
 DEPEND="
 	app-arch/7zip
@@ -63,6 +63,7 @@ DEPEND="
 	media-libs/libpng:=
 	media-libs/openal
 	media-libs/rtmidi
+	media-libs/libsdl3[opengl,vulkan?,X?,wayland?]
 	media-video/ffmpeg:=
 	net-libs/miniupnpc:=
 	net-misc/curl

--- a/games-emulation/rpcs3/rpcs3-9999.ebuild
+++ b/games-emulation/rpcs3/rpcs3-9999.ebuild
@@ -43,7 +43,7 @@ fi
 
 LICENSE="GPL-2"
 SLOT="0"
-IUSE="discord faudio +llvm opencv vulkan wayland"
+IUSE="discord faudio +llvm opencv vulkan X wayland"
 
 DEPEND="
 	app-arch/7zip
@@ -63,6 +63,7 @@ DEPEND="
 	media-libs/libpng:=
 	media-libs/openal
 	media-libs/rtmidi
+	media-libs/libsdl3[opengl,vulkan?,X?,wayland?]
 	media-video/ffmpeg:=
 	net-libs/miniupnpc:=
 	net-misc/curl


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/977905

`pkgcheck scan ...` is clean.
However `pkgcheck scan --net ...` has DeaUrl warning.

```
games-emulation/rpcs3
  DeadUrl: version 0.0.41: HOMEPAGE: 403 Client Error: Forbidden for url: https://rpcs3.net/
```

This may be due to security checks when accessing the site. --> https://rpcs3.net/
One idea to deal with this would be to link to the github page instead, since it shows their website there anyway.
But yeah, the url is in fact not dead.

Please let me know if I should update the url or not.