### PR TITLE
games-emulation/RetroArch: add desktop database update

### DIFF
--- a/games-emulation/RetroArch/RetroArch-1.21.0.ebuild
+++ b/games-emulation/RetroArch/RetroArch-1.21.0.ebuild
@@ -194,4 +194,12 @@ pkg_postinst() {
 		ewarn "Make sure you have OSS installed in your system."
 		ewarn ""
 	fi
+
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
 }

--- a/games-emulation/RetroArch/RetroArch-1.21.0.ebuild
+++ b/games-emulation/RetroArch/RetroArch-1.21.0.ebuild
@@ -44,7 +44,7 @@ RDEPEND="
 	x11-libs/libXScrnSaver
 	alsa? ( media-libs/alsa-lib )
 	cg? ( media-gfx/nvidia-cg-toolkit:0= )
-	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
+	arm? ( dispmanx? ( dev-embedded/raspberrypi-utils:0 ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
 	jack? ( virtual/jack:= )
 	libass? ( media-libs/libass:0= )

--- a/games-emulation/RetroArch/RetroArch-1.22.2.ebuild
+++ b/games-emulation/RetroArch/RetroArch-1.22.2.ebuild
@@ -191,4 +191,12 @@ pkg_postinst() {
 		ewarn "Make sure you have OSS installed in your system."
 		ewarn ""
 	fi
+
+	xdg_desktop_database_update
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_desktop_database_update
+	xdg_icon_cache_update
 }

--- a/games-emulation/RetroArch/RetroArch-1.22.2.ebuild
+++ b/games-emulation/RetroArch/RetroArch-1.22.2.ebuild
@@ -44,7 +44,7 @@ RDEPEND="
 	x11-libs/libXScrnSaver
 	alsa? ( media-libs/alsa-lib )
 	cg? ( media-gfx/nvidia-cg-toolkit:0= )
-	arm? ( dispmanx? ( || ( media-libs/raspberrypi-userland:0 media-libs/raspberrypi-userland-bin:0 ) ) )
+	arm? ( dispmanx? ( dev-embedded/raspberrypi-utils:0 ) )
 	ffmpeg? ( >=media-video/ffmpeg-2.1.3:0= )
 	jack? ( virtual/jack:= )
 	libass? ( media-libs/libass:0= )


### PR DESCRIPTION
```
 * QA Notice: .desktop files with MimeType= were found installed
 * but desktop mimeinfo cache has not been updated:
 *   /usr/share/applications/com.libretro.RetroArch.desktop
 * Please make sure to call xdg_desktop_database_update()
 * in pkg_postinst() and pkg_postrm() phases of appropriate pkgs.
 ```

**Closes:** https://bugs.gentoo.org/975056

the second commit addresses a dependency issue:
https://github.com/raspberrypi/userland
Apparently this is now ancient and deprecated. Some of the tools have been moved to `raspberrypi-utils`.

> The few useful tools from here (dtoverlay, dtmerge, vcmailbox, vcgencmd) have been moved to the raspberrypi/utils repo.

`pkgcheck scan --net ...` is clean.

Regards
-Gil