### PR TITLE
net-vpn/proton-vpn-gtk-app: fixed dependencies in ebuild

### DIFF
--- a/net-vpn/proton-vpn-gtk-app/proton-vpn-gtk-app-4.15.2.ebuild
+++ b/net-vpn/proton-vpn-gtk-app/proton-vpn-gtk-app-4.15.2.ebuild
@@ -16,9 +16,12 @@ SRC_URI="https://github.com/ProtonVPN/proton-vpn-gtk-app/archive/refs/tags/v${PV
 LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64"
+IUSE="elogind systemd"
 RESTRICT="test"
 
 RDEPEND="
+	elogind? ( sys-auth/elogind )
+	systemd? ( sys-apps/systemd:= )
 	$(python_gen_cond_dep '
 		dev-python/dbus-python[${PYTHON_USEDEP}]
 		dev-python/distro[${PYTHON_USEDEP}]


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/979832

Bug explains that the package requires systemd or elogind, checking the github repo of the package reveals that it does require systemd and has an error for when it isn't working. I added the use flags and dependencies for systemd and elogind to fix this.

Hopefully did everything correctly this time :)

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I have read the [GURU rules](https://wiki.gentoo.org/wiki/Project:GURU#Rules) and agree with them (note that they were last updated 2026-07-19).
- [x] I can submit this contribution in agreement with the [Copyright Policy](https://www.gentoo.org/glep/glep-0076.html#certificate-of-origin).
- [x] I have certified the above via adding a `Signed-off-by` line to *every* commit in the pull request.
- [x] This contribution has not been created with the assistance of Natural Language Processing artificial intelligence tools, in accordance with the [AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy).
- [x] I have run `pkgcheck scan --commits --net` to check for issues with my commits.

Please note that all boxes must be checked for the pull request to be merged.
